### PR TITLE
deprecate solr_bbox, solr_{sw,ne}_pt, solr_{wms,wfs,wcs}_url

### DIFF
--- a/349/10/geoblacklight.xml
+++ b/349/10/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/11/geoblacklight.xml
+++ b/349/11/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/12/geoblacklight.xml
+++ b/349/12/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/13/geoblacklight.xml
+++ b/349/13/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/14/geoblacklight.xml
+++ b/349/14/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/15/geoblacklight.xml
+++ b/349/15/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/16/geoblacklight.xml
+++ b/349/16/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/17/geoblacklight.xml
+++ b/349/17/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/18/geoblacklight.xml
+++ b/349/18/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/19/geoblacklight.xml
+++ b/349/19/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/20/geoblacklight.xml
+++ b/349/20/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/21/geoblacklight.xml
+++ b/349/21/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/22/geoblacklight.xml
+++ b/349/22/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/23/geoblacklight.xml
+++ b/349/23/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/24/geoblacklight.xml
+++ b/349/24/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/25/geoblacklight.xml
+++ b/349/25/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/26/geoblacklight.xml
+++ b/349/26/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/27/geoblacklight.xml
+++ b/349/27/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/28/geoblacklight.xml
+++ b/349/28/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/29/geoblacklight.xml
+++ b/349/29/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/30/geoblacklight.xml
+++ b/349/30/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/31/geoblacklight.xml
+++ b/349/31/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/32/geoblacklight.xml
+++ b/349/32/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/33/geoblacklight.xml
+++ b/349/33/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/34/geoblacklight.xml
+++ b/349/34/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/35/geoblacklight.xml
+++ b/349/35/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/36/geoblacklight.xml
+++ b/349/36/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/37/geoblacklight.xml
+++ b/349/37/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/38/geoblacklight.xml
+++ b/349/38/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/39/geoblacklight.xml
+++ b/349/39/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/4/geoblacklight.xml
+++ b/349/4/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/40/geoblacklight.xml
+++ b/349/40/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/41/geoblacklight.xml
+++ b/349/41/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/42/geoblacklight.xml
+++ b/349/42/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/43/geoblacklight.xml
+++ b/349/43/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/44/geoblacklight.xml
+++ b/349/44/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/45/geoblacklight.xml
+++ b/349/45/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/46/geoblacklight.xml
+++ b/349/46/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/47/geoblacklight.xml
+++ b/349/47/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/48/geoblacklight.xml
+++ b/349/48/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/49/geoblacklight.xml
+++ b/349/49/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/5/geoblacklight.xml
+++ b/349/5/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/50/geoblacklight.xml
+++ b/349/50/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/51/geoblacklight.xml
+++ b/349/51/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/52/geoblacklight.xml
+++ b/349/52/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/53/geoblacklight.xml
+++ b/349/53/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/54/geoblacklight.xml
+++ b/349/54/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/55/geoblacklight.xml
+++ b/349/55/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/56/geoblacklight.xml
+++ b/349/56/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/57/geoblacklight.xml
+++ b/349/57/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/58/geoblacklight.xml
+++ b/349/58/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/59/geoblacklight.xml
+++ b/349/59/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/6/geoblacklight.xml
+++ b/349/6/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/60/geoblacklight.xml
+++ b/349/60/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/61/geoblacklight.xml
+++ b/349/61/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/62/geoblacklight.xml
+++ b/349/62/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/63/geoblacklight.xml
+++ b/349/63/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/64/geoblacklight.xml
+++ b/349/64/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/65/geoblacklight.xml
+++ b/349/65/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/66/geoblacklight.xml
+++ b/349/66/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/67/geoblacklight.xml
+++ b/349/67/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/68/geoblacklight.xml
+++ b/349/68/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/69/geoblacklight.xml
+++ b/349/69/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/7/geoblacklight.xml
+++ b/349/7/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/70/geoblacklight.xml
+++ b/349/70/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/71/geoblacklight.xml
+++ b/349/71/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/72/geoblacklight.xml
+++ b/349/72/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/73/geoblacklight.xml
+++ b/349/73/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/74/geoblacklight.xml
+++ b/349/74/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/75/geoblacklight.xml
+++ b/349/75/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/76/geoblacklight.xml
+++ b/349/76/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/77/geoblacklight.xml
+++ b/349/77/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/78/geoblacklight.xml
+++ b/349/78/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/79/geoblacklight.xml
+++ b/349/79/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/8/geoblacklight.xml
+++ b/349/8/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/80/geoblacklight.xml
+++ b/349/80/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/81/geoblacklight.xml
+++ b/349/81/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/349/9/geoblacklight.xml
+++ b/349/9/geoblacklight.xml
@@ -93,12 +93,6 @@ Voting Precincts * Elementary School
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/10/geoblacklight.xml
+++ b/355/10/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/100/geoblacklight.xml
+++ b/355/100/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/101/geoblacklight.xml
+++ b/355/101/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/102/geoblacklight.xml
+++ b/355/102/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/103/geoblacklight.xml
+++ b/355/103/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/104/geoblacklight.xml
+++ b/355/104/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/105/geoblacklight.xml
+++ b/355/105/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/106/geoblacklight.xml
+++ b/355/106/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/107/geoblacklight.xml
+++ b/355/107/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/108/geoblacklight.xml
+++ b/355/108/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/109/geoblacklight.xml
+++ b/355/109/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/11/geoblacklight.xml
+++ b/355/11/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/110/geoblacklight.xml
+++ b/355/110/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/111/geoblacklight.xml
+++ b/355/111/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/112/geoblacklight.xml
+++ b/355/112/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/113/geoblacklight.xml
+++ b/355/113/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/114/geoblacklight.xml
+++ b/355/114/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/115/geoblacklight.xml
+++ b/355/115/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/116/geoblacklight.xml
+++ b/355/116/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/117/geoblacklight.xml
+++ b/355/117/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/118/geoblacklight.xml
+++ b/355/118/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/119/geoblacklight.xml
+++ b/355/119/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/12/geoblacklight.xml
+++ b/355/12/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/120/geoblacklight.xml
+++ b/355/120/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/121/geoblacklight.xml
+++ b/355/121/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/122/geoblacklight.xml
+++ b/355/122/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/123/geoblacklight.xml
+++ b/355/123/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/124/geoblacklight.xml
+++ b/355/124/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/125/geoblacklight.xml
+++ b/355/125/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/126/geoblacklight.xml
+++ b/355/126/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/127/geoblacklight.xml
+++ b/355/127/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/128/geoblacklight.xml
+++ b/355/128/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/129/geoblacklight.xml
+++ b/355/129/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/13/geoblacklight.xml
+++ b/355/13/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/14/geoblacklight.xml
+++ b/355/14/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/15/geoblacklight.xml
+++ b/355/15/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/16/geoblacklight.xml
+++ b/355/16/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/17/geoblacklight.xml
+++ b/355/17/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/18/geoblacklight.xml
+++ b/355/18/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/19/geoblacklight.xml
+++ b/355/19/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/20/geoblacklight.xml
+++ b/355/20/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/21/geoblacklight.xml
+++ b/355/21/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/22/geoblacklight.xml
+++ b/355/22/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/23/geoblacklight.xml
+++ b/355/23/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/24/geoblacklight.xml
+++ b/355/24/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/25/geoblacklight.xml
+++ b/355/25/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/26/geoblacklight.xml
+++ b/355/26/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/27/geoblacklight.xml
+++ b/355/27/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/28/geoblacklight.xml
+++ b/355/28/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/29/geoblacklight.xml
+++ b/355/29/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/30/geoblacklight.xml
+++ b/355/30/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/31/geoblacklight.xml
+++ b/355/31/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/32/geoblacklight.xml
+++ b/355/32/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/33/geoblacklight.xml
+++ b/355/33/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/34/geoblacklight.xml
+++ b/355/34/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/35/geoblacklight.xml
+++ b/355/35/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/36/geoblacklight.xml
+++ b/355/36/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/37/geoblacklight.xml
+++ b/355/37/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/38/geoblacklight.xml
+++ b/355/38/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/39/geoblacklight.xml
+++ b/355/39/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/4/geoblacklight.xml
+++ b/355/4/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/40/geoblacklight.xml
+++ b/355/40/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/41/geoblacklight.xml
+++ b/355/41/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/42/geoblacklight.xml
+++ b/355/42/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/43/geoblacklight.xml
+++ b/355/43/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/44/geoblacklight.xml
+++ b/355/44/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/45/geoblacklight.xml
+++ b/355/45/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/46/geoblacklight.xml
+++ b/355/46/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/47/geoblacklight.xml
+++ b/355/47/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/48/geoblacklight.xml
+++ b/355/48/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/49/geoblacklight.xml
+++ b/355/49/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/5/geoblacklight.xml
+++ b/355/5/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/50/geoblacklight.xml
+++ b/355/50/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/51/geoblacklight.xml
+++ b/355/51/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/52/geoblacklight.xml
+++ b/355/52/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/53/geoblacklight.xml
+++ b/355/53/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/54/geoblacklight.xml
+++ b/355/54/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/55/geoblacklight.xml
+++ b/355/55/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/56/geoblacklight.xml
+++ b/355/56/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/57/geoblacklight.xml
+++ b/355/57/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/58/geoblacklight.xml
+++ b/355/58/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/59/geoblacklight.xml
+++ b/355/59/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/6/geoblacklight.xml
+++ b/355/6/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/60/geoblacklight.xml
+++ b/355/60/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/61/geoblacklight.xml
+++ b/355/61/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/62/geoblacklight.xml
+++ b/355/62/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/63/geoblacklight.xml
+++ b/355/63/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/64/geoblacklight.xml
+++ b/355/64/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/65/geoblacklight.xml
+++ b/355/65/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/66/geoblacklight.xml
+++ b/355/66/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/67/geoblacklight.xml
+++ b/355/67/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/68/geoblacklight.xml
+++ b/355/68/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/69/geoblacklight.xml
+++ b/355/69/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/7/geoblacklight.xml
+++ b/355/7/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/70/geoblacklight.xml
+++ b/355/70/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/71/geoblacklight.xml
+++ b/355/71/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/72/geoblacklight.xml
+++ b/355/72/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/73/geoblacklight.xml
+++ b/355/73/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/74/geoblacklight.xml
+++ b/355/74/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/75/geoblacklight.xml
+++ b/355/75/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/76/geoblacklight.xml
+++ b/355/76/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/77/geoblacklight.xml
+++ b/355/77/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/78/geoblacklight.xml
+++ b/355/78/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/79/geoblacklight.xml
+++ b/355/79/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/8/geoblacklight.xml
+++ b/355/8/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/80/geoblacklight.xml
+++ b/355/80/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/81/geoblacklight.xml
+++ b/355/81/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/82/geoblacklight.xml
+++ b/355/82/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/83/geoblacklight.xml
+++ b/355/83/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/84/geoblacklight.xml
+++ b/355/84/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/85/geoblacklight.xml
+++ b/355/85/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/86/geoblacklight.xml
+++ b/355/86/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/87/geoblacklight.xml
+++ b/355/87/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/88/geoblacklight.xml
+++ b/355/88/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/89/geoblacklight.xml
+++ b/355/89/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/9/geoblacklight.xml
+++ b/355/9/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/90/geoblacklight.xml
+++ b/355/90/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/91/geoblacklight.xml
+++ b/355/91/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/92/geoblacklight.xml
+++ b/355/92/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/93/geoblacklight.xml
+++ b/355/93/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/94/geoblacklight.xml
+++ b/355/94/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/95/geoblacklight.xml
+++ b/355/95/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/96/geoblacklight.xml
+++ b/355/96/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/97/geoblacklight.xml
+++ b/355/97/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/98/geoblacklight.xml
+++ b/355/98/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/355/99/geoblacklight.xml
+++ b/355/99/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/10/geoblacklight.xml
+++ b/356/10/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/100/geoblacklight.xml
+++ b/356/100/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/101/geoblacklight.xml
+++ b/356/101/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/102/geoblacklight.xml
+++ b/356/102/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/103/geoblacklight.xml
+++ b/356/103/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/104/geoblacklight.xml
+++ b/356/104/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/105/geoblacklight.xml
+++ b/356/105/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/106/geoblacklight.xml
+++ b/356/106/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/107/geoblacklight.xml
+++ b/356/107/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/108/geoblacklight.xml
+++ b/356/108/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/109/geoblacklight.xml
+++ b/356/109/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/11/geoblacklight.xml
+++ b/356/11/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/110/geoblacklight.xml
+++ b/356/110/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/111/geoblacklight.xml
+++ b/356/111/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/112/geoblacklight.xml
+++ b/356/112/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/113/geoblacklight.xml
+++ b/356/113/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/114/geoblacklight.xml
+++ b/356/114/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/115/geoblacklight.xml
+++ b/356/115/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/116/geoblacklight.xml
+++ b/356/116/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/117/geoblacklight.xml
+++ b/356/117/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/118/geoblacklight.xml
+++ b/356/118/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/119/geoblacklight.xml
+++ b/356/119/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/12/geoblacklight.xml
+++ b/356/12/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/120/geoblacklight.xml
+++ b/356/120/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/121/geoblacklight.xml
+++ b/356/121/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/122/geoblacklight.xml
+++ b/356/122/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/123/geoblacklight.xml
+++ b/356/123/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/124/geoblacklight.xml
+++ b/356/124/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/125/geoblacklight.xml
+++ b/356/125/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/126/geoblacklight.xml
+++ b/356/126/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/127/geoblacklight.xml
+++ b/356/127/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/128/geoblacklight.xml
+++ b/356/128/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/129/geoblacklight.xml
+++ b/356/129/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/13/geoblacklight.xml
+++ b/356/13/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/130/geoblacklight.xml
+++ b/356/130/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/131/geoblacklight.xml
+++ b/356/131/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/132/geoblacklight.xml
+++ b/356/132/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/133/geoblacklight.xml
+++ b/356/133/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/134/geoblacklight.xml
+++ b/356/134/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/135/geoblacklight.xml
+++ b/356/135/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/14/geoblacklight.xml
+++ b/356/14/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/15/geoblacklight.xml
+++ b/356/15/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/16/geoblacklight.xml
+++ b/356/16/geoblacklight.xml
@@ -57,12 +57,6 @@ AsSubNbhdPly_Type</field>
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/17/geoblacklight.xml
+++ b/356/17/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/18/geoblacklight.xml
+++ b/356/18/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/19/geoblacklight.xml
+++ b/356/19/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/20/geoblacklight.xml
+++ b/356/20/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/21/geoblacklight.xml
+++ b/356/21/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/22/geoblacklight.xml
+++ b/356/22/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/23/geoblacklight.xml
+++ b/356/23/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/24/geoblacklight.xml
+++ b/356/24/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/25/geoblacklight.xml
+++ b/356/25/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/26/geoblacklight.xml
+++ b/356/26/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/27/geoblacklight.xml
+++ b/356/27/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/28/geoblacklight.xml
+++ b/356/28/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/29/geoblacklight.xml
+++ b/356/29/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/30/geoblacklight.xml
+++ b/356/30/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/31/geoblacklight.xml
+++ b/356/31/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/32/geoblacklight.xml
+++ b/356/32/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/33/geoblacklight.xml
+++ b/356/33/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/34/geoblacklight.xml
+++ b/356/34/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/35/geoblacklight.xml
+++ b/356/35/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/36/geoblacklight.xml
+++ b/356/36/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/37/geoblacklight.xml
+++ b/356/37/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/38/geoblacklight.xml
+++ b/356/38/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/39/geoblacklight.xml
+++ b/356/39/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/4/geoblacklight.xml
+++ b/356/4/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/40/geoblacklight.xml
+++ b/356/40/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/41/geoblacklight.xml
+++ b/356/41/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/42/geoblacklight.xml
+++ b/356/42/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/43/geoblacklight.xml
+++ b/356/43/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/44/geoblacklight.xml
+++ b/356/44/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/45/geoblacklight.xml
+++ b/356/45/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/46/geoblacklight.xml
+++ b/356/46/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/47/geoblacklight.xml
+++ b/356/47/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/48/geoblacklight.xml
+++ b/356/48/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/49/geoblacklight.xml
+++ b/356/49/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/5/geoblacklight.xml
+++ b/356/5/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/50/geoblacklight.xml
+++ b/356/50/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/51/geoblacklight.xml
+++ b/356/51/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/52/geoblacklight.xml
+++ b/356/52/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/53/geoblacklight.xml
+++ b/356/53/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/54/geoblacklight.xml
+++ b/356/54/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/55/geoblacklight.xml
+++ b/356/55/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/56/geoblacklight.xml
+++ b/356/56/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/57/geoblacklight.xml
+++ b/356/57/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/58/geoblacklight.xml
+++ b/356/58/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/59/geoblacklight.xml
+++ b/356/59/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/6/geoblacklight.xml
+++ b/356/6/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/60/geoblacklight.xml
+++ b/356/60/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/61/geoblacklight.xml
+++ b/356/61/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/62/geoblacklight.xml
+++ b/356/62/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/63/geoblacklight.xml
+++ b/356/63/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/64/geoblacklight.xml
+++ b/356/64/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/65/geoblacklight.xml
+++ b/356/65/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/66/geoblacklight.xml
+++ b/356/66/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/67/geoblacklight.xml
+++ b/356/67/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/68/geoblacklight.xml
+++ b/356/68/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/69/geoblacklight.xml
+++ b/356/69/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/7/geoblacklight.xml
+++ b/356/7/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/70/geoblacklight.xml
+++ b/356/70/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/71/geoblacklight.xml
+++ b/356/71/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/72/geoblacklight.xml
+++ b/356/72/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/73/geoblacklight.xml
+++ b/356/73/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/74/geoblacklight.xml
+++ b/356/74/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/75/geoblacklight.xml
+++ b/356/75/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/76/geoblacklight.xml
+++ b/356/76/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/77/geoblacklight.xml
+++ b/356/77/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/78/geoblacklight.xml
+++ b/356/78/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/79/geoblacklight.xml
+++ b/356/79/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/8/geoblacklight.xml
+++ b/356/8/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/80/geoblacklight.xml
+++ b/356/80/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/81/geoblacklight.xml
+++ b/356/81/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/82/geoblacklight.xml
+++ b/356/82/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/83/geoblacklight.xml
+++ b/356/83/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/84/geoblacklight.xml
+++ b/356/84/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/85/geoblacklight.xml
+++ b/356/85/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/86/geoblacklight.xml
+++ b/356/86/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/87/geoblacklight.xml
+++ b/356/87/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/88/geoblacklight.xml
+++ b/356/88/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/89/geoblacklight.xml
+++ b/356/89/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/9/geoblacklight.xml
+++ b/356/9/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/90/geoblacklight.xml
+++ b/356/90/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/91/geoblacklight.xml
+++ b/356/91/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/92/geoblacklight.xml
+++ b/356/92/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/93/geoblacklight.xml
+++ b/356/93/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/94/geoblacklight.xml
+++ b/356/94/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/95/geoblacklight.xml
+++ b/356/95/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/96/geoblacklight.xml
+++ b/356/96/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/97/geoblacklight.xml
+++ b/356/97/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/98/geoblacklight.xml
+++ b/356/98/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/356/99/geoblacklight.xml
+++ b/356/99/geoblacklight.xml
@@ -47,12 +47,6 @@
     <field name="georss_box_s">38.79163 -77.11990 38.99596 -76.90912</field>
     <field name="georss_polygon_s">38.79163 -77.11990 38.79163 -76.90912 38.99596 -76.90912 38.99596 -77.11990 38.79163 -77.11990</field>
     <field name="solr_geom">ENVELOPE(-77.11990, -76.90912, 38.99596, -76.90912)</field>
-    <field name="solr_bbox">-77.11990 38.79163 -76.90912 38.99596</field>
-    <field name="solr_sw_pt">38.79163,-77.11990</field>
-    <field name="solr_ne_pt">38.99596,-76.90912</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/10/geoblacklight.xml
+++ b/359/10/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/11/geoblacklight.xml
+++ b/359/11/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/12/geoblacklight.xml
+++ b/359/12/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/13/geoblacklight.xml
+++ b/359/13/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/14/geoblacklight.xml
+++ b/359/14/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/15/geoblacklight.xml
+++ b/359/15/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/16/geoblacklight.xml
+++ b/359/16/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/17/geoblacklight.xml
+++ b/359/17/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/18/geoblacklight.xml
+++ b/359/18/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/4/geoblacklight.xml
+++ b/359/4/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/5/geoblacklight.xml
+++ b/359/5/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/6/geoblacklight.xml
+++ b/359/6/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/7/geoblacklight.xml
+++ b/359/7/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/8/geoblacklight.xml
+++ b/359/8/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/359/9/geoblacklight.xml
+++ b/359/9/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">29 60 39 75</field>
     <field name="georss_polygon_s">29 60 29 75 39 75 39 60 29 60</field>
     <field name="solr_geom">ENVELOPE(60, 75, 39, 75)</field>
-    <field name="solr_bbox">60 29 75 39</field>
-    <field name="solr_sw_pt">29,60</field>
-    <field name="solr_ne_pt">39,75</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/10/geoblacklight.xml
+++ b/360/10/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/11/geoblacklight.xml
+++ b/360/11/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/12/geoblacklight.xml
+++ b/360/12/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/13/geoblacklight.xml
+++ b/360/13/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/14/geoblacklight.xml
+++ b/360/14/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/15/geoblacklight.xml
+++ b/360/15/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/16/geoblacklight.xml
+++ b/360/16/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/17/geoblacklight.xml
+++ b/360/17/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/18/geoblacklight.xml
+++ b/360/18/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/19/geoblacklight.xml
+++ b/360/19/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/20/geoblacklight.xml
+++ b/360/20/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/21/geoblacklight.xml
+++ b/360/21/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/22/geoblacklight.xml
+++ b/360/22/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/23/geoblacklight.xml
+++ b/360/23/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/24/geoblacklight.xml
+++ b/360/24/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/25/geoblacklight.xml
+++ b/360/25/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/26/geoblacklight.xml
+++ b/360/26/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/27/geoblacklight.xml
+++ b/360/27/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/28/geoblacklight.xml
+++ b/360/28/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/29/geoblacklight.xml
+++ b/360/29/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/30/geoblacklight.xml
+++ b/360/30/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/31/geoblacklight.xml
+++ b/360/31/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/32/geoblacklight.xml
+++ b/360/32/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/33/geoblacklight.xml
+++ b/360/33/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/34/geoblacklight.xml
+++ b/360/34/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/35/geoblacklight.xml
+++ b/360/35/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/36/geoblacklight.xml
+++ b/360/36/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/37/geoblacklight.xml
+++ b/360/37/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/38/geoblacklight.xml
+++ b/360/38/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/39/geoblacklight.xml
+++ b/360/39/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/4/geoblacklight.xml
+++ b/360/4/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/40/geoblacklight.xml
+++ b/360/40/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/41/geoblacklight.xml
+++ b/360/41/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/42/geoblacklight.xml
+++ b/360/42/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/43/geoblacklight.xml
+++ b/360/43/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/44/geoblacklight.xml
+++ b/360/44/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/45/geoblacklight.xml
+++ b/360/45/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/46/geoblacklight.xml
+++ b/360/46/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/47/geoblacklight.xml
+++ b/360/47/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/48/geoblacklight.xml
+++ b/360/48/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/49/geoblacklight.xml
+++ b/360/49/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/5/geoblacklight.xml
+++ b/360/5/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/50/geoblacklight.xml
+++ b/360/50/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/51/geoblacklight.xml
+++ b/360/51/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/52/geoblacklight.xml
+++ b/360/52/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/53/geoblacklight.xml
+++ b/360/53/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/54/geoblacklight.xml
+++ b/360/54/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/55/geoblacklight.xml
+++ b/360/55/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/56/geoblacklight.xml
+++ b/360/56/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/57/geoblacklight.xml
+++ b/360/57/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/58/geoblacklight.xml
+++ b/360/58/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/59/geoblacklight.xml
+++ b/360/59/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/6/geoblacklight.xml
+++ b/360/6/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/60/geoblacklight.xml
+++ b/360/60/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/61/geoblacklight.xml
+++ b/360/61/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/62/geoblacklight.xml
+++ b/360/62/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/63/geoblacklight.xml
+++ b/360/63/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/64/geoblacklight.xml
+++ b/360/64/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/65/geoblacklight.xml
+++ b/360/65/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/66/geoblacklight.xml
+++ b/360/66/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/67/geoblacklight.xml
+++ b/360/67/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/68/geoblacklight.xml
+++ b/360/68/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/69/geoblacklight.xml
+++ b/360/69/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/7/geoblacklight.xml
+++ b/360/7/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/70/geoblacklight.xml
+++ b/360/70/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/71/geoblacklight.xml
+++ b/360/71/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/72/geoblacklight.xml
+++ b/360/72/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/73/geoblacklight.xml
+++ b/360/73/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/74/geoblacklight.xml
+++ b/360/74/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/75/geoblacklight.xml
+++ b/360/75/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/76/geoblacklight.xml
+++ b/360/76/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/77/geoblacklight.xml
+++ b/360/77/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/78/geoblacklight.xml
+++ b/360/78/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/79/geoblacklight.xml
+++ b/360/79/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/8/geoblacklight.xml
+++ b/360/8/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/80/geoblacklight.xml
+++ b/360/80/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/81/geoblacklight.xml
+++ b/360/81/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/82/geoblacklight.xml
+++ b/360/82/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/83/geoblacklight.xml
+++ b/360/83/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/84/geoblacklight.xml
+++ b/360/84/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/85/geoblacklight.xml
+++ b/360/85/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/86/geoblacklight.xml
+++ b/360/86/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/87/geoblacklight.xml
+++ b/360/87/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/88/geoblacklight.xml
+++ b/360/88/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/89/geoblacklight.xml
+++ b/360/89/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/9/geoblacklight.xml
+++ b/360/9/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/90/geoblacklight.xml
+++ b/360/90/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/91/geoblacklight.xml
+++ b/360/91/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/92/geoblacklight.xml
+++ b/360/92/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/93/geoblacklight.xml
+++ b/360/93/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/94/geoblacklight.xml
+++ b/360/94/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/95/geoblacklight.xml
+++ b/360/95/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/96/geoblacklight.xml
+++ b/360/96/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/97/geoblacklight.xml
+++ b/360/97/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/360/98/geoblacklight.xml
+++ b/360/98/geoblacklight.xml
@@ -126,12 +126,6 @@ year of updated in 2003)
     <field name="georss_box_s">38.82678 -77.17349 38.93489 -77.03046</field>
     <field name="georss_polygon_s">38.82678 -77.17349 38.82678 -77.03046 38.93489 -77.03046 38.93489 -77.17349 38.82678 -77.17349</field>
     <field name="solr_geom">ENVELOPE(-77.17349, -77.03046, 38.93489, -77.03046)</field>
-    <field name="solr_bbox">-77.17349 38.82678 -77.03046 38.93489</field>
-    <field name="solr_sw_pt">38.82678,-77.17349</field>
-    <field name="solr_ne_pt">38.93489,-77.03046</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/10/geoblacklight.xml
+++ b/362/10/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/11/geoblacklight.xml
+++ b/362/11/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/12/geoblacklight.xml
+++ b/362/12/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/13/geoblacklight.xml
+++ b/362/13/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/14/geoblacklight.xml
+++ b/362/14/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/15/geoblacklight.xml
+++ b/362/15/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/16/geoblacklight.xml
+++ b/362/16/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/17/geoblacklight.xml
+++ b/362/17/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/18/geoblacklight.xml
+++ b/362/18/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/19/geoblacklight.xml
+++ b/362/19/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/20/geoblacklight.xml
+++ b/362/20/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/21/geoblacklight.xml
+++ b/362/21/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/22/geoblacklight.xml
+++ b/362/22/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/23/geoblacklight.xml
+++ b/362/23/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/24/geoblacklight.xml
+++ b/362/24/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/25/geoblacklight.xml
+++ b/362/25/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/26/geoblacklight.xml
+++ b/362/26/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/27/geoblacklight.xml
+++ b/362/27/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/28/geoblacklight.xml
+++ b/362/28/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/29/geoblacklight.xml
+++ b/362/29/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/30/geoblacklight.xml
+++ b/362/30/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/31/geoblacklight.xml
+++ b/362/31/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/32/geoblacklight.xml
+++ b/362/32/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/33/geoblacklight.xml
+++ b/362/33/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/34/geoblacklight.xml
+++ b/362/34/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/35/geoblacklight.xml
+++ b/362/35/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/36/geoblacklight.xml
+++ b/362/36/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/37/geoblacklight.xml
+++ b/362/37/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/38/geoblacklight.xml
+++ b/362/38/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/39/geoblacklight.xml
+++ b/362/39/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/4/geoblacklight.xml
+++ b/362/4/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/40/geoblacklight.xml
+++ b/362/40/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/41/geoblacklight.xml
+++ b/362/41/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/42/geoblacklight.xml
+++ b/362/42/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/5/geoblacklight.xml
+++ b/362/5/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/6/geoblacklight.xml
+++ b/362/6/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/7/geoblacklight.xml
+++ b/362/7/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/8/geoblacklight.xml
+++ b/362/8/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/362/9/geoblacklight.xml
+++ b/362/9/geoblacklight.xml
@@ -87,12 +87,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.78585 -77.14433 38.84494 -77.03728</field>
     <field name="georss_polygon_s">38.78585 -77.14433 38.78585 -77.03728 38.84494 -77.03728 38.84494 -77.14433 38.78585 -77.14433</field>
     <field name="solr_geom">ENVELOPE(-77.14433, -77.03728, 38.84494, -77.03728)</field>
-    <field name="solr_bbox">-77.14433 38.78585 -77.03728 38.84494</field>
-    <field name="solr_sw_pt">38.78585,-77.14433</field>
-    <field name="solr_ne_pt">38.84494,-77.03728</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/10/geoblacklight.xml
+++ b/366/10/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/100/geoblacklight.xml
+++ b/366/100/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/101/geoblacklight.xml
+++ b/366/101/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/102/geoblacklight.xml
+++ b/366/102/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/103/geoblacklight.xml
+++ b/366/103/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/104/geoblacklight.xml
+++ b/366/104/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/105/geoblacklight.xml
+++ b/366/105/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/106/geoblacklight.xml
+++ b/366/106/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/107/geoblacklight.xml
+++ b/366/107/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/108/geoblacklight.xml
+++ b/366/108/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/11/geoblacklight.xml
+++ b/366/11/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/12/geoblacklight.xml
+++ b/366/12/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/13/geoblacklight.xml
+++ b/366/13/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/14/geoblacklight.xml
+++ b/366/14/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/15/geoblacklight.xml
+++ b/366/15/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/16/geoblacklight.xml
+++ b/366/16/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/17/geoblacklight.xml
+++ b/366/17/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/18/geoblacklight.xml
+++ b/366/18/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/19/geoblacklight.xml
+++ b/366/19/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/20/geoblacklight.xml
+++ b/366/20/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/21/geoblacklight.xml
+++ b/366/21/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/22/geoblacklight.xml
+++ b/366/22/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/23/geoblacklight.xml
+++ b/366/23/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/24/geoblacklight.xml
+++ b/366/24/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/25/geoblacklight.xml
+++ b/366/25/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/26/geoblacklight.xml
+++ b/366/26/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/27/geoblacklight.xml
+++ b/366/27/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/28/geoblacklight.xml
+++ b/366/28/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/29/geoblacklight.xml
+++ b/366/29/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/30/geoblacklight.xml
+++ b/366/30/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/31/geoblacklight.xml
+++ b/366/31/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/32/geoblacklight.xml
+++ b/366/32/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/33/geoblacklight.xml
+++ b/366/33/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/34/geoblacklight.xml
+++ b/366/34/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/35/geoblacklight.xml
+++ b/366/35/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/36/geoblacklight.xml
+++ b/366/36/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/37/geoblacklight.xml
+++ b/366/37/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/38/geoblacklight.xml
+++ b/366/38/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/39/geoblacklight.xml
+++ b/366/39/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/4/geoblacklight.xml
+++ b/366/4/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/40/geoblacklight.xml
+++ b/366/40/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/41/geoblacklight.xml
+++ b/366/41/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/42/geoblacklight.xml
+++ b/366/42/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/43/geoblacklight.xml
+++ b/366/43/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/44/geoblacklight.xml
+++ b/366/44/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/45/geoblacklight.xml
+++ b/366/45/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/46/geoblacklight.xml
+++ b/366/46/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/47/geoblacklight.xml
+++ b/366/47/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/48/geoblacklight.xml
+++ b/366/48/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/49/geoblacklight.xml
+++ b/366/49/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/5/geoblacklight.xml
+++ b/366/5/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/50/geoblacklight.xml
+++ b/366/50/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/51/geoblacklight.xml
+++ b/366/51/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/52/geoblacklight.xml
+++ b/366/52/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/53/geoblacklight.xml
+++ b/366/53/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/54/geoblacklight.xml
+++ b/366/54/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/55/geoblacklight.xml
+++ b/366/55/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/56/geoblacklight.xml
+++ b/366/56/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/57/geoblacklight.xml
+++ b/366/57/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/58/geoblacklight.xml
+++ b/366/58/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/59/geoblacklight.xml
+++ b/366/59/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/6/geoblacklight.xml
+++ b/366/6/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/60/geoblacklight.xml
+++ b/366/60/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/61/geoblacklight.xml
+++ b/366/61/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/62/geoblacklight.xml
+++ b/366/62/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/63/geoblacklight.xml
+++ b/366/63/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/64/geoblacklight.xml
+++ b/366/64/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/65/geoblacklight.xml
+++ b/366/65/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/66/geoblacklight.xml
+++ b/366/66/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/67/geoblacklight.xml
+++ b/366/67/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/68/geoblacklight.xml
+++ b/366/68/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/69/geoblacklight.xml
+++ b/366/69/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/7/geoblacklight.xml
+++ b/366/7/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/70/geoblacklight.xml
+++ b/366/70/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/71/geoblacklight.xml
+++ b/366/71/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/72/geoblacklight.xml
+++ b/366/72/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/73/geoblacklight.xml
+++ b/366/73/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/74/geoblacklight.xml
+++ b/366/74/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/75/geoblacklight.xml
+++ b/366/75/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/76/geoblacklight.xml
+++ b/366/76/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/77/geoblacklight.xml
+++ b/366/77/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/78/geoblacklight.xml
+++ b/366/78/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/79/geoblacklight.xml
+++ b/366/79/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/8/geoblacklight.xml
+++ b/366/8/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/80/geoblacklight.xml
+++ b/366/80/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/81/geoblacklight.xml
+++ b/366/81/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/82/geoblacklight.xml
+++ b/366/82/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/83/geoblacklight.xml
+++ b/366/83/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/84/geoblacklight.xml
+++ b/366/84/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/85/geoblacklight.xml
+++ b/366/85/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/86/geoblacklight.xml
+++ b/366/86/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/87/geoblacklight.xml
+++ b/366/87/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/88/geoblacklight.xml
+++ b/366/88/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/89/geoblacklight.xml
+++ b/366/89/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/9/geoblacklight.xml
+++ b/366/9/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/90/geoblacklight.xml
+++ b/366/90/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/91/geoblacklight.xml
+++ b/366/91/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/92/geoblacklight.xml
+++ b/366/92/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/93/geoblacklight.xml
+++ b/366/93/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/94/geoblacklight.xml
+++ b/366/94/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/95/geoblacklight.xml
+++ b/366/95/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/96/geoblacklight.xml
+++ b/366/96/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/97/geoblacklight.xml
+++ b/366/97/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/98/geoblacklight.xml
+++ b/366/98/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/366/99/geoblacklight.xml
+++ b/366/99/geoblacklight.xml
@@ -114,12 +114,6 @@
     <field name="georss_box_s">38.60369 -77.53701 39.05767 -77.04136</field>
     <field name="georss_polygon_s">38.60369 -77.53701 38.60369 -77.04136 39.05767 -77.04136 39.05767 -77.53701 38.60369 -77.53701</field>
     <field name="solr_geom">ENVELOPE(-77.53701, -77.04136, 39.05767, -77.04136)</field>
-    <field name="solr_bbox">-77.53701 38.60369 -77.04136 39.05767</field>
-    <field name="solr_sw_pt">38.60369,-77.53701</field>
-    <field name="solr_ne_pt">39.05767,-77.04136</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/10/geoblacklight.xml
+++ b/367/10/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/11/geoblacklight.xml
+++ b/367/11/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/12/geoblacklight.xml
+++ b/367/12/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/13/geoblacklight.xml
+++ b/367/13/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/14/geoblacklight.xml
+++ b/367/14/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/15/geoblacklight.xml
+++ b/367/15/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/16/geoblacklight.xml
+++ b/367/16/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/17/geoblacklight.xml
+++ b/367/17/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/18/geoblacklight.xml
+++ b/367/18/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/19/geoblacklight.xml
+++ b/367/19/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/20/geoblacklight.xml
+++ b/367/20/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/21/geoblacklight.xml
+++ b/367/21/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/22/geoblacklight.xml
+++ b/367/22/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/23/geoblacklight.xml
+++ b/367/23/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/24/geoblacklight.xml
+++ b/367/24/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/25/geoblacklight.xml
+++ b/367/25/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/26/geoblacklight.xml
+++ b/367/26/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/27/geoblacklight.xml
+++ b/367/27/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/28/geoblacklight.xml
+++ b/367/28/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/29/geoblacklight.xml
+++ b/367/29/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/30/geoblacklight.xml
+++ b/367/30/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/31/geoblacklight.xml
+++ b/367/31/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/32/geoblacklight.xml
+++ b/367/32/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/33/geoblacklight.xml
+++ b/367/33/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/34/geoblacklight.xml
+++ b/367/34/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/35/geoblacklight.xml
+++ b/367/35/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/36/geoblacklight.xml
+++ b/367/36/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/37/geoblacklight.xml
+++ b/367/37/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/38/geoblacklight.xml
+++ b/367/38/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/39/geoblacklight.xml
+++ b/367/39/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/4/geoblacklight.xml
+++ b/367/4/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/40/geoblacklight.xml
+++ b/367/40/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/5/geoblacklight.xml
+++ b/367/5/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/6/geoblacklight.xml
+++ b/367/6/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/7/geoblacklight.xml
+++ b/367/7/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/8/geoblacklight.xml
+++ b/367/8/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/367/9/geoblacklight.xml
+++ b/367/9/geoblacklight.xml
@@ -66,12 +66,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.54200 -76.49801 36.87145 -76.05655</field>
     <field name="georss_polygon_s">36.54200 -76.49801 36.54200 -76.05655 36.87145 -76.05655 36.87145 -76.49801 36.54200 -76.49801</field>
     <field name="solr_geom">ENVELOPE(-76.49801, -76.05655, 36.87145, -76.05655)</field>
-    <field name="solr_bbox">-76.49801 36.54200 -76.05655 36.87145</field>
-    <field name="solr_sw_pt">36.54200,-76.49801</field>
-    <field name="solr_ne_pt">36.87145,-76.05655</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/10/geoblacklight.xml
+++ b/368/10/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/11/geoblacklight.xml
+++ b/368/11/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/12/geoblacklight.xml
+++ b/368/12/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/13/geoblacklight.xml
+++ b/368/13/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/14/geoblacklight.xml
+++ b/368/14/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/15/geoblacklight.xml
+++ b/368/15/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/16/geoblacklight.xml
+++ b/368/16/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/17/geoblacklight.xml
+++ b/368/17/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/18/geoblacklight.xml
+++ b/368/18/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/19/geoblacklight.xml
+++ b/368/19/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/20/geoblacklight.xml
+++ b/368/20/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/21/geoblacklight.xml
+++ b/368/21/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/22/geoblacklight.xml
+++ b/368/22/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/23/geoblacklight.xml
+++ b/368/23/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/24/geoblacklight.xml
+++ b/368/24/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/25/geoblacklight.xml
+++ b/368/25/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/26/geoblacklight.xml
+++ b/368/26/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/27/geoblacklight.xml
+++ b/368/27/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/28/geoblacklight.xml
+++ b/368/28/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/29/geoblacklight.xml
+++ b/368/29/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/30/geoblacklight.xml
+++ b/368/30/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/31/geoblacklight.xml
+++ b/368/31/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/32/geoblacklight.xml
+++ b/368/32/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/33/geoblacklight.xml
+++ b/368/33/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/34/geoblacklight.xml
+++ b/368/34/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/35/geoblacklight.xml
+++ b/368/35/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/36/geoblacklight.xml
+++ b/368/36/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/37/geoblacklight.xml
+++ b/368/37/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/38/geoblacklight.xml
+++ b/368/38/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/39/geoblacklight.xml
+++ b/368/39/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/4/geoblacklight.xml
+++ b/368/4/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/40/geoblacklight.xml
+++ b/368/40/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/41/geoblacklight.xml
+++ b/368/41/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/42/geoblacklight.xml
+++ b/368/42/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/5/geoblacklight.xml
+++ b/368/5/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/6/geoblacklight.xml
+++ b/368/6/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/7/geoblacklight.xml
+++ b/368/7/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/8/geoblacklight.xml
+++ b/368/8/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/368/9/geoblacklight.xml
+++ b/368/9/geoblacklight.xml
@@ -83,12 +83,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.44625 -77.60278 37.60507 -77.38319</field>
     <field name="georss_polygon_s">37.44625 -77.60278 37.44625 -77.38319 37.60507 -77.38319 37.60507 -77.60278 37.44625 -77.60278</field>
     <field name="solr_geom">ENVELOPE(-77.60278, -77.38319, 37.60507, -77.38319)</field>
-    <field name="solr_bbox">-77.60278 37.44625 -77.38319 37.60507</field>
-    <field name="solr_sw_pt">37.44625,-77.60278</field>
-    <field name="solr_ne_pt">37.60507,-77.38319</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/10/geoblacklight.xml
+++ b/373/10/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/11/geoblacklight.xml
+++ b/373/11/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/12/geoblacklight.xml
+++ b/373/12/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/13/geoblacklight.xml
+++ b/373/13/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/14/geoblacklight.xml
+++ b/373/14/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/15/geoblacklight.xml
+++ b/373/15/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/16/geoblacklight.xml
+++ b/373/16/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/17/geoblacklight.xml
+++ b/373/17/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/18/geoblacklight.xml
+++ b/373/18/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/19/geoblacklight.xml
+++ b/373/19/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/20/geoblacklight.xml
+++ b/373/20/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/4/geoblacklight.xml
+++ b/373/4/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/5/geoblacklight.xml
+++ b/373/5/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/6/geoblacklight.xml
+++ b/373/6/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/7/geoblacklight.xml
+++ b/373/7/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/8/geoblacklight.xml
+++ b/373/8/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/373/9/geoblacklight.xml
+++ b/373/9/geoblacklight.xml
@@ -65,12 +65,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.53800 -77.80500 38.00800 -77.10800</field>
     <field name="georss_polygon_s">37.53800 -77.80500 37.53800 -77.10800 38.00800 -77.10800 38.00800 -77.80500 37.53800 -77.80500</field>
     <field name="solr_geom">ENVELOPE(-77.80500, -77.10800, 38.00800, -77.10800)</field>
-    <field name="solr_bbox">-77.80500 37.53800 -77.10800 38.00800</field>
-    <field name="solr_sw_pt">37.53800,-77.80500</field>
-    <field name="solr_ne_pt">38.00800,-77.10800</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/10/geoblacklight.xml
+++ b/380/10/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/11/geoblacklight.xml
+++ b/380/11/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/12/geoblacklight.xml
+++ b/380/12/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/13/geoblacklight.xml
+++ b/380/13/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/14/geoblacklight.xml
+++ b/380/14/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/15/geoblacklight.xml
+++ b/380/15/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/16/geoblacklight.xml
+++ b/380/16/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/17/geoblacklight.xml
+++ b/380/17/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/18/geoblacklight.xml
+++ b/380/18/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/19/geoblacklight.xml
+++ b/380/19/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/20/geoblacklight.xml
+++ b/380/20/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/21/geoblacklight.xml
+++ b/380/21/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/22/geoblacklight.xml
+++ b/380/22/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/4/geoblacklight.xml
+++ b/380/4/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/5/geoblacklight.xml
+++ b/380/5/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/6/geoblacklight.xml
+++ b/380/6/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/7/geoblacklight.xml
+++ b/380/7/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/8/geoblacklight.xml
+++ b/380/8/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/380/9/geoblacklight.xml
+++ b/380/9/geoblacklight.xml
@@ -63,12 +63,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">37.35230 -77.65805 37.71074 -77.17331</field>
     <field name="georss_polygon_s">37.35230 -77.65805 37.35230 -77.17331 37.71074 -77.17331 37.71074 -77.65805 37.35230 -77.65805</field>
     <field name="solr_geom">ENVELOPE(-77.65805, -77.17331, 37.71074, -77.17331)</field>
-    <field name="solr_bbox">-77.65805 37.35230 -77.17331 37.71074</field>
-    <field name="solr_sw_pt">37.35230,-77.65805</field>
-    <field name="solr_ne_pt">37.71074,-77.17331</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/10/geoblacklight.xml
+++ b/381/10/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/11/geoblacklight.xml
+++ b/381/11/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/12/geoblacklight.xml
+++ b/381/12/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/13/geoblacklight.xml
+++ b/381/13/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/14/geoblacklight.xml
+++ b/381/14/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/15/geoblacklight.xml
+++ b/381/15/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/16/geoblacklight.xml
+++ b/381/16/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/17/geoblacklight.xml
+++ b/381/17/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/18/geoblacklight.xml
+++ b/381/18/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/4/geoblacklight.xml
+++ b/381/4/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/5/geoblacklight.xml
+++ b/381/5/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/6/geoblacklight.xml
+++ b/381/6/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/7/geoblacklight.xml
+++ b/381/7/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/8/geoblacklight.xml
+++ b/381/8/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/381/9/geoblacklight.xml
+++ b/381/9/geoblacklight.xml
@@ -53,12 +53,6 @@ More detailed descriptions of the datasets and coding schemes can be found via t
     <field name="georss_box_s">37.55000 -78.52700 38.89700 -76.28100</field>
     <field name="georss_polygon_s">37.55000 -78.52700 37.55000 -76.28100 38.89700 -76.28100 38.89700 -78.52700 37.55000 -78.52700</field>
     <field name="solr_geom">ENVELOPE(-78.52700, -76.28100, 38.89700, -76.28100)</field>
-    <field name="solr_bbox">-78.52700 37.55000 -76.28100 38.89700</field>
-    <field name="solr_sw_pt">37.55000,-78.52700</field>
-    <field name="solr_ne_pt">38.89700,-76.28100</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/10/geoblacklight.xml
+++ b/382/10/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/11/geoblacklight.xml
+++ b/382/11/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/12/geoblacklight.xml
+++ b/382/12/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/13/geoblacklight.xml
+++ b/382/13/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/14/geoblacklight.xml
+++ b/382/14/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/15/geoblacklight.xml
+++ b/382/15/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/16/geoblacklight.xml
+++ b/382/16/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/17/geoblacklight.xml
+++ b/382/17/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/18/geoblacklight.xml
+++ b/382/18/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/19/geoblacklight.xml
+++ b/382/19/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/4/geoblacklight.xml
+++ b/382/4/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/5/geoblacklight.xml
+++ b/382/5/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/6/geoblacklight.xml
+++ b/382/6/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/7/geoblacklight.xml
+++ b/382/7/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/8/geoblacklight.xml
+++ b/382/8/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/382/9/geoblacklight.xml
+++ b/382/9/geoblacklight.xml
@@ -64,12 +64,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.82000 -76.34600 36.97100 -76.17600</field>
     <field name="georss_polygon_s">36.82000 -76.34600 36.82000 -76.17600 36.97100 -76.17600 36.97100 -76.34600 36.82000 -76.34600</field>
     <field name="solr_geom">ENVELOPE(-76.34600, -76.17600, 36.97100, -76.17600)</field>
-    <field name="solr_bbox">-76.34600 36.82000 -76.17600 36.97100</field>
-    <field name="solr_sw_pt">36.82000,-76.34600</field>
-    <field name="solr_ne_pt">36.97100,-76.17600</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/383/4/geoblacklight.xml
+++ b/383/4/geoblacklight.xml
@@ -46,12 +46,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.78600 -76.42100 36.89900 -76.28900</field>
     <field name="georss_polygon_s">36.78600 -76.42100 36.78600 -76.28900 36.89900 -76.28900 36.89900 -76.42100 36.78600 -76.42100</field>
     <field name="solr_geom">ENVELOPE(-76.42100, -76.28900, 36.89900, -76.28900)</field>
-    <field name="solr_bbox">-76.42100 36.78600 -76.28900 36.89900</field>
-    <field name="solr_sw_pt">36.78600,-76.42100</field>
-    <field name="solr_ne_pt">36.89900,-76.28900</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/383/5/geoblacklight.xml
+++ b/383/5/geoblacklight.xml
@@ -46,12 +46,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.78600 -76.42100 36.89900 -76.28900</field>
     <field name="georss_polygon_s">36.78600 -76.42100 36.78600 -76.28900 36.89900 -76.28900 36.89900 -76.42100 36.78600 -76.42100</field>
     <field name="solr_geom">ENVELOPE(-76.42100, -76.28900, 36.89900, -76.28900)</field>
-    <field name="solr_bbox">-76.42100 36.78600 -76.28900 36.89900</field>
-    <field name="solr_sw_pt">36.78600,-76.42100</field>
-    <field name="solr_ne_pt">36.89900,-76.28900</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/383/6/geoblacklight.xml
+++ b/383/6/geoblacklight.xml
@@ -46,12 +46,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">36.78600 -76.42100 36.89900 -76.28900</field>
     <field name="georss_polygon_s">36.78600 -76.42100 36.78600 -76.28900 36.89900 -76.28900 36.89900 -76.42100 36.78600 -76.42100</field>
     <field name="solr_geom">ENVELOPE(-76.42100, -76.28900, 36.89900, -76.28900)</field>
-    <field name="solr_bbox">-76.42100 36.78600 -76.28900 36.89900</field>
-    <field name="solr_sw_pt">36.78600,-76.42100</field>
-    <field name="solr_ne_pt">36.89900,-76.28900</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/10/geoblacklight.xml
+++ b/386/10/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/11/geoblacklight.xml
+++ b/386/11/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/12/geoblacklight.xml
+++ b/386/12/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/13/geoblacklight.xml
+++ b/386/13/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/14/geoblacklight.xml
+++ b/386/14/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/15/geoblacklight.xml
+++ b/386/15/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/16/geoblacklight.xml
+++ b/386/16/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/17/geoblacklight.xml
+++ b/386/17/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/18/geoblacklight.xml
+++ b/386/18/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/19/geoblacklight.xml
+++ b/386/19/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/20/geoblacklight.xml
+++ b/386/20/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/21/geoblacklight.xml
+++ b/386/21/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/22/geoblacklight.xml
+++ b/386/22/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/23/geoblacklight.xml
+++ b/386/23/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/24/geoblacklight.xml
+++ b/386/24/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/25/geoblacklight.xml
+++ b/386/25/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/26/geoblacklight.xml
+++ b/386/26/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/27/geoblacklight.xml
+++ b/386/27/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/28/geoblacklight.xml
+++ b/386/28/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/29/geoblacklight.xml
+++ b/386/29/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/30/geoblacklight.xml
+++ b/386/30/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/31/geoblacklight.xml
+++ b/386/31/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/32/geoblacklight.xml
+++ b/386/32/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/33/geoblacklight.xml
+++ b/386/33/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/34/geoblacklight.xml
+++ b/386/34/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/35/geoblacklight.xml
+++ b/386/35/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/36/geoblacklight.xml
+++ b/386/36/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/4/geoblacklight.xml
+++ b/386/4/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/5/geoblacklight.xml
+++ b/386/5/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/6/geoblacklight.xml
+++ b/386/6/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/7/geoblacklight.xml
+++ b/386/7/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/8/geoblacklight.xml
+++ b/386/8/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/386/9/geoblacklight.xml
+++ b/386/9/geoblacklight.xml
@@ -76,12 +76,6 @@ These data were made available to the University of Virginia for educational and
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/10/geoblacklight.xml
+++ b/389/10/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/11/geoblacklight.xml
+++ b/389/11/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/12/geoblacklight.xml
+++ b/389/12/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/13/geoblacklight.xml
+++ b/389/13/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/14/geoblacklight.xml
+++ b/389/14/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/15/geoblacklight.xml
+++ b/389/15/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/16/geoblacklight.xml
+++ b/389/16/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/17/geoblacklight.xml
+++ b/389/17/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/18/geoblacklight.xml
+++ b/389/18/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/19/geoblacklight.xml
+++ b/389/19/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/20/geoblacklight.xml
+++ b/389/20/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/21/geoblacklight.xml
+++ b/389/21/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/22/geoblacklight.xml
+++ b/389/22/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/23/geoblacklight.xml
+++ b/389/23/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/24/geoblacklight.xml
+++ b/389/24/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/25/geoblacklight.xml
+++ b/389/25/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/26/geoblacklight.xml
+++ b/389/26/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/27/geoblacklight.xml
+++ b/389/27/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/28/geoblacklight.xml
+++ b/389/28/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/29/geoblacklight.xml
+++ b/389/29/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/30/geoblacklight.xml
+++ b/389/30/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/31/geoblacklight.xml
+++ b/389/31/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/32/geoblacklight.xml
+++ b/389/32/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/33/geoblacklight.xml
+++ b/389/33/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/34/geoblacklight.xml
+++ b/389/34/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/35/geoblacklight.xml
+++ b/389/35/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/36/geoblacklight.xml
+++ b/389/36/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/37/geoblacklight.xml
+++ b/389/37/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/38/geoblacklight.xml
+++ b/389/38/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/39/geoblacklight.xml
+++ b/389/39/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/4/geoblacklight.xml
+++ b/389/4/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/40/geoblacklight.xml
+++ b/389/40/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/41/geoblacklight.xml
+++ b/389/41/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/42/geoblacklight.xml
+++ b/389/42/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/43/geoblacklight.xml
+++ b/389/43/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/44/geoblacklight.xml
+++ b/389/44/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/45/geoblacklight.xml
+++ b/389/45/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/46/geoblacklight.xml
+++ b/389/46/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/47/geoblacklight.xml
+++ b/389/47/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/48/geoblacklight.xml
+++ b/389/48/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/49/geoblacklight.xml
+++ b/389/49/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/5/geoblacklight.xml
+++ b/389/5/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/50/geoblacklight.xml
+++ b/389/50/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/51/geoblacklight.xml
+++ b/389/51/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/52/geoblacklight.xml
+++ b/389/52/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/53/geoblacklight.xml
+++ b/389/53/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/54/geoblacklight.xml
+++ b/389/54/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/55/geoblacklight.xml
+++ b/389/55/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/56/geoblacklight.xml
+++ b/389/56/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/57/geoblacklight.xml
+++ b/389/57/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/58/geoblacklight.xml
+++ b/389/58/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/59/geoblacklight.xml
+++ b/389/59/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/6/geoblacklight.xml
+++ b/389/6/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/60/geoblacklight.xml
+++ b/389/60/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/61/geoblacklight.xml
+++ b/389/61/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/62/geoblacklight.xml
+++ b/389/62/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/63/geoblacklight.xml
+++ b/389/63/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/64/geoblacklight.xml
+++ b/389/64/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/65/geoblacklight.xml
+++ b/389/65/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/66/geoblacklight.xml
+++ b/389/66/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/67/geoblacklight.xml
+++ b/389/67/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/68/geoblacklight.xml
+++ b/389/68/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/69/geoblacklight.xml
+++ b/389/69/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/7/geoblacklight.xml
+++ b/389/7/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/70/geoblacklight.xml
+++ b/389/70/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/8/geoblacklight.xml
+++ b/389/8/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/389/9/geoblacklight.xml
+++ b/389/9/geoblacklight.xml
@@ -98,12 +98,6 @@
     <field name="georss_box_s">38.84437 -77.96328 39.32594 -77.32408</field>
     <field name="georss_polygon_s">38.84437 -77.96328 38.84437 -77.32408 39.32594 -77.32408 39.32594 -77.96328 38.84437 -77.96328</field>
     <field name="solr_geom">ENVELOPE(-77.96328, -77.32408, 39.32594, -77.32408)</field>
-    <field name="solr_bbox">-77.96328 38.84437 -77.32408 39.32594</field>
-    <field name="solr_sw_pt">38.84437,-77.96328</field>
-    <field name="solr_ne_pt">39.32594,-77.32408</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/394/10/geoblacklight.xml
+++ b/394/10/geoblacklight.xml
@@ -52,12 +52,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">38.01878 -78.55270 38.05735 -78.48499</field>
     <field name="georss_polygon_s">38.01878 -78.55270 38.01878 -78.48499 38.05735 -78.48499 38.05735 -78.55270 38.01878 -78.55270</field>
     <field name="solr_geom">ENVELOPE(-78.55270, -78.48499, 38.05735, -78.48499)</field>
-    <field name="solr_bbox">-78.55270 38.01878 -78.48499 38.05735</field>
-    <field name="solr_sw_pt">38.01878,-78.55270</field>
-    <field name="solr_ne_pt">38.05735,-78.48499</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/394/11/geoblacklight.xml
+++ b/394/11/geoblacklight.xml
@@ -52,12 +52,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">38.01878 -78.55270 38.05735 -78.48499</field>
     <field name="georss_polygon_s">38.01878 -78.55270 38.01878 -78.48499 38.05735 -78.48499 38.05735 -78.55270 38.01878 -78.55270</field>
     <field name="solr_geom">ENVELOPE(-78.55270, -78.48499, 38.05735, -78.48499)</field>
-    <field name="solr_bbox">-78.55270 38.01878 -78.48499 38.05735</field>
-    <field name="solr_sw_pt">38.01878,-78.55270</field>
-    <field name="solr_ne_pt">38.05735,-78.48499</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/394/12/geoblacklight.xml
+++ b/394/12/geoblacklight.xml
@@ -52,12 +52,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">38.01878 -78.55270 38.05735 -78.48499</field>
     <field name="georss_polygon_s">38.01878 -78.55270 38.01878 -78.48499 38.05735 -78.48499 38.05735 -78.55270 38.01878 -78.55270</field>
     <field name="solr_geom">ENVELOPE(-78.55270, -78.48499, 38.05735, -78.48499)</field>
-    <field name="solr_bbox">-78.55270 38.01878 -78.48499 38.05735</field>
-    <field name="solr_sw_pt">38.01878,-78.55270</field>
-    <field name="solr_ne_pt">38.05735,-78.48499</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/394/13/geoblacklight.xml
+++ b/394/13/geoblacklight.xml
@@ -52,12 +52,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">38.01878 -78.55270 38.05735 -78.48499</field>
     <field name="georss_polygon_s">38.01878 -78.55270 38.01878 -78.48499 38.05735 -78.48499 38.05735 -78.55270 38.01878 -78.55270</field>
     <field name="solr_geom">ENVELOPE(-78.55270, -78.48499, 38.05735, -78.48499)</field>
-    <field name="solr_bbox">-78.55270 38.01878 -78.48499 38.05735</field>
-    <field name="solr_sw_pt">38.01878,-78.55270</field>
-    <field name="solr_ne_pt">38.05735,-78.48499</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/394/14/geoblacklight.xml
+++ b/394/14/geoblacklight.xml
@@ -52,12 +52,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">38.01878 -78.55270 38.05735 -78.48499</field>
     <field name="georss_polygon_s">38.01878 -78.55270 38.01878 -78.48499 38.05735 -78.48499 38.05735 -78.55270 38.01878 -78.55270</field>
     <field name="solr_geom">ENVELOPE(-78.55270, -78.48499, 38.05735, -78.48499)</field>
-    <field name="solr_bbox">-78.55270 38.01878 -78.48499 38.05735</field>
-    <field name="solr_sw_pt">38.01878,-78.55270</field>
-    <field name="solr_ne_pt">38.05735,-78.48499</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/394/15/geoblacklight.xml
+++ b/394/15/geoblacklight.xml
@@ -52,12 +52,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">38.01878 -78.55270 38.05735 -78.48499</field>
     <field name="georss_polygon_s">38.01878 -78.55270 38.01878 -78.48499 38.05735 -78.48499 38.05735 -78.55270 38.01878 -78.55270</field>
     <field name="solr_geom">ENVELOPE(-78.55270, -78.48499, 38.05735, -78.48499)</field>
-    <field name="solr_bbox">-78.55270 38.01878 -78.48499 38.05735</field>
-    <field name="solr_sw_pt">38.01878,-78.55270</field>
-    <field name="solr_ne_pt">38.05735,-78.48499</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/394/4/geoblacklight.xml
+++ b/394/4/geoblacklight.xml
@@ -52,12 +52,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">38.01878 -78.55270 38.05735 -78.48499</field>
     <field name="georss_polygon_s">38.01878 -78.55270 38.01878 -78.48499 38.05735 -78.48499 38.05735 -78.55270 38.01878 -78.55270</field>
     <field name="solr_geom">ENVELOPE(-78.55270, -78.48499, 38.05735, -78.48499)</field>
-    <field name="solr_bbox">-78.55270 38.01878 -78.48499 38.05735</field>
-    <field name="solr_sw_pt">38.01878,-78.55270</field>
-    <field name="solr_ne_pt">38.05735,-78.48499</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/394/5/geoblacklight.xml
+++ b/394/5/geoblacklight.xml
@@ -52,12 +52,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">38.01878 -78.55270 38.05735 -78.48499</field>
     <field name="georss_polygon_s">38.01878 -78.55270 38.01878 -78.48499 38.05735 -78.48499 38.05735 -78.55270 38.01878 -78.55270</field>
     <field name="solr_geom">ENVELOPE(-78.55270, -78.48499, 38.05735, -78.48499)</field>
-    <field name="solr_bbox">-78.55270 38.01878 -78.48499 38.05735</field>
-    <field name="solr_sw_pt">38.01878,-78.55270</field>
-    <field name="solr_ne_pt">38.05735,-78.48499</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/394/6/geoblacklight.xml
+++ b/394/6/geoblacklight.xml
@@ -52,12 +52,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">38.01878 -78.55270 38.05735 -78.48499</field>
     <field name="georss_polygon_s">38.01878 -78.55270 38.01878 -78.48499 38.05735 -78.48499 38.05735 -78.55270 38.01878 -78.55270</field>
     <field name="solr_geom">ENVELOPE(-78.55270, -78.48499, 38.05735, -78.48499)</field>
-    <field name="solr_bbox">-78.55270 38.01878 -78.48499 38.05735</field>
-    <field name="solr_sw_pt">38.01878,-78.55270</field>
-    <field name="solr_ne_pt">38.05735,-78.48499</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/394/7/geoblacklight.xml
+++ b/394/7/geoblacklight.xml
@@ -52,12 +52,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">38.01878 -78.55270 38.05735 -78.48499</field>
     <field name="georss_polygon_s">38.01878 -78.55270 38.01878 -78.48499 38.05735 -78.48499 38.05735 -78.55270 38.01878 -78.55270</field>
     <field name="solr_geom">ENVELOPE(-78.55270, -78.48499, 38.05735, -78.48499)</field>
-    <field name="solr_bbox">-78.55270 38.01878 -78.48499 38.05735</field>
-    <field name="solr_sw_pt">38.01878,-78.55270</field>
-    <field name="solr_ne_pt">38.05735,-78.48499</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/394/8/geoblacklight.xml
+++ b/394/8/geoblacklight.xml
@@ -52,12 +52,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">38.01878 -78.55270 38.05735 -78.48499</field>
     <field name="georss_polygon_s">38.01878 -78.55270 38.01878 -78.48499 38.05735 -78.48499 38.05735 -78.55270 38.01878 -78.55270</field>
     <field name="solr_geom">ENVELOPE(-78.55270, -78.48499, 38.05735, -78.48499)</field>
-    <field name="solr_bbox">-78.55270 38.01878 -78.48499 38.05735</field>
-    <field name="solr_sw_pt">38.01878,-78.55270</field>
-    <field name="solr_ne_pt">38.05735,-78.48499</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/394/9/geoblacklight.xml
+++ b/394/9/geoblacklight.xml
@@ -52,12 +52,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">38.01878 -78.55270 38.05735 -78.48499</field>
     <field name="georss_polygon_s">38.01878 -78.55270 38.01878 -78.48499 38.05735 -78.48499 38.05735 -78.55270 38.01878 -78.55270</field>
     <field name="solr_geom">ENVELOPE(-78.55270, -78.48499, 38.05735, -78.48499)</field>
-    <field name="solr_bbox">-78.55270 38.01878 -78.48499 38.05735</field>
-    <field name="solr_sw_pt">38.01878,-78.55270</field>
-    <field name="solr_ne_pt">38.05735,-78.48499</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/395/4/geoblacklight.xml
+++ b/395/4/geoblacklight.xml
@@ -41,12 +41,6 @@
     <field name="georss_box_s">36.45 -83.7 39.51 -75.1</field>
     <field name="georss_polygon_s">36.45 -83.7 36.45 -75.1 39.51 -75.1 39.51 -83.7 36.45 -83.7</field>
     <field name="solr_geom">ENVELOPE(-83.7, -75.1, 39.51, -75.1)</field>
-    <field name="solr_bbox">-83.7 36.45 -75.1 39.51</field>
-    <field name="solr_sw_pt">36.45,-83.7</field>
-    <field name="solr_ne_pt">39.51,-75.1</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/395/5/geoblacklight.xml
+++ b/395/5/geoblacklight.xml
@@ -41,12 +41,6 @@
     <field name="georss_box_s">36.45 -83.7 39.51 -75.1</field>
     <field name="georss_polygon_s">36.45 -83.7 36.45 -75.1 39.51 -75.1 39.51 -83.7 36.45 -83.7</field>
     <field name="solr_geom">ENVELOPE(-83.7, -75.1, 39.51, -75.1)</field>
-    <field name="solr_bbox">-83.7 36.45 -75.1 39.51</field>
-    <field name="solr_sw_pt">36.45,-83.7</field>
-    <field name="solr_ne_pt">39.51,-75.1</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/395/6/geoblacklight.xml
+++ b/395/6/geoblacklight.xml
@@ -41,12 +41,6 @@
     <field name="georss_box_s">36.45 -83.7 39.51 -75.1</field>
     <field name="georss_polygon_s">36.45 -83.7 36.45 -75.1 39.51 -75.1 39.51 -83.7 36.45 -83.7</field>
     <field name="solr_geom">ENVELOPE(-83.7, -75.1, 39.51, -75.1)</field>
-    <field name="solr_bbox">-83.7 36.45 -75.1 39.51</field>
-    <field name="solr_sw_pt">36.45,-83.7</field>
-    <field name="solr_ne_pt">39.51,-75.1</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/395/7/geoblacklight.xml
+++ b/395/7/geoblacklight.xml
@@ -41,12 +41,6 @@
     <field name="georss_box_s">36.45 -83.7 39.51 -75.1</field>
     <field name="georss_polygon_s">36.45 -83.7 36.45 -75.1 39.51 -75.1 39.51 -83.7 36.45 -83.7</field>
     <field name="solr_geom">ENVELOPE(-83.7, -75.1, 39.51, -75.1)</field>
-    <field name="solr_bbox">-83.7 36.45 -75.1 39.51</field>
-    <field name="solr_sw_pt">36.45,-83.7</field>
-    <field name="solr_ne_pt">39.51,-75.1</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/395/8/geoblacklight.xml
+++ b/395/8/geoblacklight.xml
@@ -41,12 +41,6 @@
     <field name="georss_box_s">36.45 -83.7 39.51 -75.1</field>
     <field name="georss_polygon_s">36.45 -83.7 36.45 -75.1 39.51 -75.1 39.51 -83.7 36.45 -83.7</field>
     <field name="solr_geom">ENVELOPE(-83.7, -75.1, 39.51, -75.1)</field>
-    <field name="solr_bbox">-83.7 36.45 -75.1 39.51</field>
-    <field name="solr_sw_pt">36.45,-83.7</field>
-    <field name="solr_ne_pt">39.51,-75.1</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/395/9/geoblacklight.xml
+++ b/395/9/geoblacklight.xml
@@ -41,12 +41,6 @@
     <field name="georss_box_s">36.45 -83.7 39.51 -75.1</field>
     <field name="georss_polygon_s">36.45 -83.7 36.45 -75.1 39.51 -75.1 39.51 -83.7 36.45 -83.7</field>
     <field name="solr_geom">ENVELOPE(-83.7, -75.1, 39.51, -75.1)</field>
-    <field name="solr_bbox">-83.7 36.45 -75.1 39.51</field>
-    <field name="solr_sw_pt">36.45,-83.7</field>
-    <field name="solr_ne_pt">39.51,-75.1</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/397/4/geoblacklight.xml
+++ b/397/4/geoblacklight.xml
@@ -38,12 +38,6 @@ datastack is generally in the 2004-2008 range, but some datasets may include att
     <field name="georss_box_s">36.458983 -83.830748 39.4468 -75.245577</field>
     <field name="georss_polygon_s">36.458983 -83.830748 36.458983 -75.245577 39.4468 -75.245577 39.4468 -83.830748 36.458983 -83.830748</field>
     <field name="solr_geom">ENVELOPE(-83.830748, -75.245577, 39.4468, -75.245577)</field>
-    <field name="solr_bbox">-83.830748 36.458983 -75.245577 39.4468</field>
-    <field name="solr_sw_pt">36.458983,-83.830748</field>
-    <field name="solr_ne_pt">39.4468,-75.245577</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/397/5/geoblacklight.xml
+++ b/397/5/geoblacklight.xml
@@ -38,12 +38,6 @@ datastack is generally in the 2004-2008 range, but some datasets may include att
     <field name="georss_box_s">36.458983 -83.830748 39.4468 -75.245577</field>
     <field name="georss_polygon_s">36.458983 -83.830748 36.458983 -75.245577 39.4468 -75.245577 39.4468 -83.830748 36.458983 -83.830748</field>
     <field name="solr_geom">ENVELOPE(-83.830748, -75.245577, 39.4468, -75.245577)</field>
-    <field name="solr_bbox">-83.830748 36.458983 -75.245577 39.4468</field>
-    <field name="solr_sw_pt">36.458983,-83.830748</field>
-    <field name="solr_ne_pt">39.4468,-75.245577</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/10/geoblacklight.xml
+++ b/398/10/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/11/geoblacklight.xml
+++ b/398/11/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/12/geoblacklight.xml
+++ b/398/12/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/13/geoblacklight.xml
+++ b/398/13/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/14/geoblacklight.xml
+++ b/398/14/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/15/geoblacklight.xml
+++ b/398/15/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/16/geoblacklight.xml
+++ b/398/16/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/17/geoblacklight.xml
+++ b/398/17/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/18/geoblacklight.xml
+++ b/398/18/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/19/geoblacklight.xml
+++ b/398/19/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/20/geoblacklight.xml
+++ b/398/20/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/21/geoblacklight.xml
+++ b/398/21/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/22/geoblacklight.xml
+++ b/398/22/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/23/geoblacklight.xml
+++ b/398/23/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/24/geoblacklight.xml
+++ b/398/24/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/25/geoblacklight.xml
+++ b/398/25/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/26/geoblacklight.xml
+++ b/398/26/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/27/geoblacklight.xml
+++ b/398/27/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/28/geoblacklight.xml
+++ b/398/28/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/29/geoblacklight.xml
+++ b/398/29/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/30/geoblacklight.xml
+++ b/398/30/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/31/geoblacklight.xml
+++ b/398/31/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/32/geoblacklight.xml
+++ b/398/32/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/33/geoblacklight.xml
+++ b/398/33/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/34/geoblacklight.xml
+++ b/398/34/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/35/geoblacklight.xml
+++ b/398/35/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/36/geoblacklight.xml
+++ b/398/36/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/37/geoblacklight.xml
+++ b/398/37/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/38/geoblacklight.xml
+++ b/398/38/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/39/geoblacklight.xml
+++ b/398/39/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/4/geoblacklight.xml
+++ b/398/4/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/40/geoblacklight.xml
+++ b/398/40/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/41/geoblacklight.xml
+++ b/398/41/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/42/geoblacklight.xml
+++ b/398/42/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/43/geoblacklight.xml
+++ b/398/43/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/44/geoblacklight.xml
+++ b/398/44/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/5/geoblacklight.xml
+++ b/398/5/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/6/geoblacklight.xml
+++ b/398/6/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/7/geoblacklight.xml
+++ b/398/7/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/8/geoblacklight.xml
+++ b/398/8/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/398/9/geoblacklight.xml
+++ b/398/9/geoblacklight.xml
@@ -41,12 +41,6 @@ BATHY1METER *  wqstations_Type *  wb_Type *   split_segs_st_polygon_Type * ma_st
     <field name="georss_box_s">36.59637 -80.99831 43.500083 -73.999555</field>
     <field name="georss_polygon_s">36.59637 -80.99831 36.59637 -73.999555 43.500083 -73.999555 43.500083 -80.99831 36.59637 -80.99831</field>
     <field name="solr_geom">ENVELOPE(-80.99831, -73.999555, 43.500083, -73.999555)</field>
-    <field name="solr_bbox">-80.99831 36.59637 -73.999555 43.500083</field>
-    <field name="solr_sw_pt">36.59637,-80.99831</field>
-    <field name="solr_ne_pt">43.500083,-73.999555</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/10/geoblacklight.xml
+++ b/403/10/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/11/geoblacklight.xml
+++ b/403/11/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/12/geoblacklight.xml
+++ b/403/12/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/13/geoblacklight.xml
+++ b/403/13/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/14/geoblacklight.xml
+++ b/403/14/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/15/geoblacklight.xml
+++ b/403/15/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/16/geoblacklight.xml
+++ b/403/16/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/17/geoblacklight.xml
+++ b/403/17/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/18/geoblacklight.xml
+++ b/403/18/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/19/geoblacklight.xml
+++ b/403/19/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/20/geoblacklight.xml
+++ b/403/20/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/21/geoblacklight.xml
+++ b/403/21/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/22/geoblacklight.xml
+++ b/403/22/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/23/geoblacklight.xml
+++ b/403/23/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/24/geoblacklight.xml
+++ b/403/24/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/25/geoblacklight.xml
+++ b/403/25/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/26/geoblacklight.xml
+++ b/403/26/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/27/geoblacklight.xml
+++ b/403/27/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/28/geoblacklight.xml
+++ b/403/28/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/29/geoblacklight.xml
+++ b/403/29/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/30/geoblacklight.xml
+++ b/403/30/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/31/geoblacklight.xml
+++ b/403/31/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/32/geoblacklight.xml
+++ b/403/32/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/33/geoblacklight.xml
+++ b/403/33/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/34/geoblacklight.xml
+++ b/403/34/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/35/geoblacklight.xml
+++ b/403/35/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/36/geoblacklight.xml
+++ b/403/36/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/37/geoblacklight.xml
+++ b/403/37/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/38/geoblacklight.xml
+++ b/403/38/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/39/geoblacklight.xml
+++ b/403/39/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/4/geoblacklight.xml
+++ b/403/4/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/40/geoblacklight.xml
+++ b/403/40/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/41/geoblacklight.xml
+++ b/403/41/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/42/geoblacklight.xml
+++ b/403/42/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/43/geoblacklight.xml
+++ b/403/43/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/44/geoblacklight.xml
+++ b/403/44/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/45/geoblacklight.xml
+++ b/403/45/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/46/geoblacklight.xml
+++ b/403/46/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/47/geoblacklight.xml
+++ b/403/47/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/48/geoblacklight.xml
+++ b/403/48/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/49/geoblacklight.xml
+++ b/403/49/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/5/geoblacklight.xml
+++ b/403/5/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/50/geoblacklight.xml
+++ b/403/50/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/51/geoblacklight.xml
+++ b/403/51/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/52/geoblacklight.xml
+++ b/403/52/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/53/geoblacklight.xml
+++ b/403/53/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/54/geoblacklight.xml
+++ b/403/54/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/55/geoblacklight.xml
+++ b/403/55/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/56/geoblacklight.xml
+++ b/403/56/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/57/geoblacklight.xml
+++ b/403/57/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/6/geoblacklight.xml
+++ b/403/6/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/7/geoblacklight.xml
+++ b/403/7/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/8/geoblacklight.xml
+++ b/403/8/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/403/9/geoblacklight.xml
+++ b/403/9/geoblacklight.xml
@@ -134,12 +134,6 @@ and the cubic convolution method of resampling.  The single-band mosaicked image
     <field name="georss_box_s">37.123 -81.126 37.511 -80.376</field>
     <field name="georss_polygon_s">37.123 -81.126 37.123 -80.376 37.511 -80.376 37.511 -81.126 37.123 -81.126</field>
     <field name="solr_geom">ENVELOPE(-81.126, -80.376, 37.511, -80.376)</field>
-    <field name="solr_bbox">-81.126 37.123 -80.376 37.511</field>
-    <field name="solr_sw_pt">37.123,-81.126</field>
-    <field name="solr_ne_pt">37.511,-80.376</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/463/10/geoblacklight.xml
+++ b/463/10/geoblacklight.xml
@@ -39,12 +39,6 @@
     <field name="georss_box_s">-35.5 14.40 -19.5 36.25</field>
     <field name="georss_polygon_s">-35.5 14.40 -35.5 36.25 -19.5 36.25 -19.5 14.40 -35.5 14.40</field>
     <field name="solr_geom">ENVELOPE(14.40, 36.25, -19.5, 36.25)</field>
-    <field name="solr_bbox">14.40 -35.5 36.25 -19.5</field>
-    <field name="solr_sw_pt">-35.5,14.40</field>
-    <field name="solr_ne_pt">-19.5,36.25</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/463/4/geoblacklight.xml
+++ b/463/4/geoblacklight.xml
@@ -39,12 +39,6 @@
     <field name="georss_box_s">-35.5 14.40 -19.5 36.25</field>
     <field name="georss_polygon_s">-35.5 14.40 -35.5 36.25 -19.5 36.25 -19.5 14.40 -35.5 14.40</field>
     <field name="solr_geom">ENVELOPE(14.40, 36.25, -19.5, 36.25)</field>
-    <field name="solr_bbox">14.40 -35.5 36.25 -19.5</field>
-    <field name="solr_sw_pt">-35.5,14.40</field>
-    <field name="solr_ne_pt">-19.5,36.25</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/463/5/geoblacklight.xml
+++ b/463/5/geoblacklight.xml
@@ -39,12 +39,6 @@
     <field name="georss_box_s">-35.5 14.40 -19.5 36.25</field>
     <field name="georss_polygon_s">-35.5 14.40 -35.5 36.25 -19.5 36.25 -19.5 14.40 -35.5 14.40</field>
     <field name="solr_geom">ENVELOPE(14.40, 36.25, -19.5, 36.25)</field>
-    <field name="solr_bbox">14.40 -35.5 36.25 -19.5</field>
-    <field name="solr_sw_pt">-35.5,14.40</field>
-    <field name="solr_ne_pt">-19.5,36.25</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/463/6/geoblacklight.xml
+++ b/463/6/geoblacklight.xml
@@ -39,12 +39,6 @@
     <field name="georss_box_s">-35.5 14.40 -19.5 36.25</field>
     <field name="georss_polygon_s">-35.5 14.40 -35.5 36.25 -19.5 36.25 -19.5 14.40 -35.5 14.40</field>
     <field name="solr_geom">ENVELOPE(14.40, 36.25, -19.5, 36.25)</field>
-    <field name="solr_bbox">14.40 -35.5 36.25 -19.5</field>
-    <field name="solr_sw_pt">-35.5,14.40</field>
-    <field name="solr_ne_pt">-19.5,36.25</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/463/7/geoblacklight.xml
+++ b/463/7/geoblacklight.xml
@@ -39,12 +39,6 @@
     <field name="georss_box_s">-35.5 14.40 -19.5 36.25</field>
     <field name="georss_polygon_s">-35.5 14.40 -35.5 36.25 -19.5 36.25 -19.5 14.40 -35.5 14.40</field>
     <field name="solr_geom">ENVELOPE(14.40, 36.25, -19.5, 36.25)</field>
-    <field name="solr_bbox">14.40 -35.5 36.25 -19.5</field>
-    <field name="solr_sw_pt">-35.5,14.40</field>
-    <field name="solr_ne_pt">-19.5,36.25</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/463/8/geoblacklight.xml
+++ b/463/8/geoblacklight.xml
@@ -39,12 +39,6 @@
     <field name="georss_box_s">-35.5 14.40 -19.5 36.25</field>
     <field name="georss_polygon_s">-35.5 14.40 -35.5 36.25 -19.5 36.25 -19.5 14.40 -35.5 14.40</field>
     <field name="solr_geom">ENVELOPE(14.40, 36.25, -19.5, 36.25)</field>
-    <field name="solr_bbox">14.40 -35.5 36.25 -19.5</field>
-    <field name="solr_sw_pt">-35.5,14.40</field>
-    <field name="solr_ne_pt">-19.5,36.25</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/463/9/geoblacklight.xml
+++ b/463/9/geoblacklight.xml
@@ -39,12 +39,6 @@
     <field name="georss_box_s">-35.5 14.40 -19.5 36.25</field>
     <field name="georss_polygon_s">-35.5 14.40 -35.5 36.25 -19.5 36.25 -19.5 14.40 -35.5 14.40</field>
     <field name="solr_geom">ENVELOPE(14.40, 36.25, -19.5, 36.25)</field>
-    <field name="solr_bbox">14.40 -35.5 36.25 -19.5</field>
-    <field name="solr_sw_pt">-35.5,14.40</field>
-    <field name="solr_ne_pt">-19.5,36.25</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/500/4/geoblacklight.xml
+++ b/500/4/geoblacklight.xml
@@ -44,12 +44,6 @@
     <field name="georss_box_s">33.871561 -84.531879 40.322111 -75.107963</field>
     <field name="georss_polygon_s">33.871561 -84.531879 33.871561 -75.107963 40.322111 -75.107963 40.322111 -84.531879 33.871561 -84.531879</field>
     <field name="solr_geom">ENVELOPE(-84.531879, -75.107963, 40.322111, -75.107963)</field>
-    <field name="solr_bbox">-84.531879 33.871561 -75.107963 40.322111</field>
-    <field name="solr_sw_pt">33.871561,-84.531879</field>
-    <field name="solr_ne_pt">40.322111,-75.107963</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/500/5/geoblacklight.xml
+++ b/500/5/geoblacklight.xml
@@ -44,12 +44,6 @@
     <field name="georss_box_s">33.871561 -84.531879 40.322111 -75.107963</field>
     <field name="georss_polygon_s">33.871561 -84.531879 33.871561 -75.107963 40.322111 -75.107963 40.322111 -84.531879 33.871561 -84.531879</field>
     <field name="solr_geom">ENVELOPE(-84.531879, -75.107963, 40.322111, -75.107963)</field>
-    <field name="solr_bbox">-84.531879 33.871561 -75.107963 40.322111</field>
-    <field name="solr_sw_pt">33.871561,-84.531879</field>
-    <field name="solr_ne_pt">40.322111,-75.107963</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/500/6/geoblacklight.xml
+++ b/500/6/geoblacklight.xml
@@ -44,12 +44,6 @@
     <field name="georss_box_s">33.871561 -84.531879 40.322111 -75.107963</field>
     <field name="georss_polygon_s">33.871561 -84.531879 33.871561 -75.107963 40.322111 -75.107963 40.322111 -84.531879 33.871561 -84.531879</field>
     <field name="solr_geom">ENVELOPE(-84.531879, -75.107963, 40.322111, -75.107963)</field>
-    <field name="solr_bbox">-84.531879 33.871561 -75.107963 40.322111</field>
-    <field name="solr_sw_pt">33.871561,-84.531879</field>
-    <field name="solr_ne_pt">40.322111,-75.107963</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/500/7/geoblacklight.xml
+++ b/500/7/geoblacklight.xml
@@ -44,12 +44,6 @@
     <field name="georss_box_s">33.871561 -84.531879 40.322111 -75.107963</field>
     <field name="georss_polygon_s">33.871561 -84.531879 33.871561 -75.107963 40.322111 -75.107963 40.322111 -84.531879 33.871561 -84.531879</field>
     <field name="solr_geom">ENVELOPE(-84.531879, -75.107963, 40.322111, -75.107963)</field>
-    <field name="solr_bbox">-84.531879 33.871561 -75.107963 40.322111</field>
-    <field name="solr_sw_pt">33.871561,-84.531879</field>
-    <field name="solr_ne_pt">40.322111,-75.107963</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/500/8/geoblacklight.xml
+++ b/500/8/geoblacklight.xml
@@ -44,12 +44,6 @@
     <field name="georss_box_s">33.871561 -84.531879 40.322111 -75.107963</field>
     <field name="georss_polygon_s">33.871561 -84.531879 33.871561 -75.107963 40.322111 -75.107963 40.322111 -84.531879 33.871561 -84.531879</field>
     <field name="solr_geom">ENVELOPE(-84.531879, -75.107963, 40.322111, -75.107963)</field>
-    <field name="solr_bbox">-84.531879 33.871561 -75.107963 40.322111</field>
-    <field name="solr_sw_pt">33.871561,-84.531879</field>
-    <field name="solr_ne_pt">40.322111,-75.107963</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/500/9/geoblacklight.xml
+++ b/500/9/geoblacklight.xml
@@ -44,12 +44,6 @@
     <field name="georss_box_s">33.871561 -84.531879 40.322111 -75.107963</field>
     <field name="georss_polygon_s">33.871561 -84.531879 33.871561 -75.107963 40.322111 -75.107963 40.322111 -84.531879 33.871561 -84.531879</field>
     <field name="solr_geom">ENVELOPE(-84.531879, -75.107963, 40.322111, -75.107963)</field>
-    <field name="solr_bbox">-84.531879 33.871561 -75.107963 40.322111</field>
-    <field name="solr_sw_pt">33.871561,-84.531879</field>
-    <field name="solr_ne_pt">40.322111,-75.107963</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/501/4/geoblacklight.xml
+++ b/501/4/geoblacklight.xml
@@ -35,12 +35,6 @@ Credit: G3884 .C4 G46 1890</field>
     <field name="georss_box_s">38.00202 -78.53148 38.05814 -78.43691</field>
     <field name="georss_polygon_s">38.00202 -78.53148 38.00202 -78.43691 38.05814 -78.43691 38.05814 -78.53148 38.00202 -78.53148</field>
     <field name="solr_geom">ENVELOPE(-78.53148, -78.43691, 38.05814, -78.43691)</field>
-    <field name="solr_bbox">-78.53148 38.00202 -78.43691 38.05814</field>
-    <field name="solr_sw_pt">38.00202,-78.53148</field>
-    <field name="solr_ne_pt">38.05814,-78.43691</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/507/4/geoblacklight.xml
+++ b/507/4/geoblacklight.xml
@@ -35,12 +35,6 @@ Credit: Area Table 7 1694 Jaillot.
     <field name="georss_box_s">-2.8432 -130.60377 70.3088 -29.40428</field>
     <field name="georss_polygon_s">-2.8432 -130.60377 -2.8432 -29.40428 70.3088 -29.40428 70.3088 -130.60377 -2.8432 -130.60377</field>
     <field name="solr_geom">ENVELOPE(-130.60377, -29.40428, 70.3088, -29.40428)</field>
-    <field name="solr_bbox">-130.60377 -2.8432 -29.40428 70.3088</field>
-    <field name="solr_sw_pt">-2.8432,-130.60377</field>
-    <field name="solr_ne_pt">70.3088,-29.40428</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/510/4/geoblacklight.xml
+++ b/510/4/geoblacklight.xml
@@ -33,12 +33,6 @@ Credit: Area Table 7 1695 Morden</field>
     <field name="georss_box_s">22.746 -100.840 49.351 -36.864</field>
     <field name="georss_polygon_s">22.746 -100.840 22.746 -36.864 49.351 -36.864 49.351 -100.840 22.746 -100.840</field>
     <field name="solr_geom">ENVELOPE(-100.840, -36.864, 49.351, -36.864)</field>
-    <field name="solr_bbox">-100.840 22.746 -36.864 49.351</field>
-    <field name="solr_sw_pt">22.746,-100.840</field>
-    <field name="solr_ne_pt">49.351,-36.864</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/512/4/geoblacklight.xml
+++ b/512/4/geoblacklight.xml
@@ -39,12 +39,6 @@
     <field name="georss_box_s">0.253874 -115.02862 58.138731 -40.58023</field>
     <field name="georss_polygon_s">0.253874 -115.02862 0.253874 -40.58023 58.138731 -40.58023 58.138731 -115.02862 0.253874 -115.02862</field>
     <field name="solr_geom">ENVELOPE(-115.02862, -40.58023, 58.138731, -40.58023)</field>
-    <field name="solr_bbox">-115.02862 0.253874 -40.58023 58.138731</field>
-    <field name="solr_sw_pt">0.253874,-115.02862</field>
-    <field name="solr_ne_pt">58.138731,-40.58023</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/516/4/geoblacklight.xml
+++ b/516/4/geoblacklight.xml
@@ -39,12 +39,6 @@
     <field name="georss_box_s">27.222251 -88.357268 50.415578 -54.974196</field>
     <field name="georss_polygon_s">27.222251 -88.357268 27.222251 -54.974196 50.415578 -54.974196 50.415578 -88.357268 27.222251 -88.357268</field>
     <field name="solr_geom">ENVELOPE(-88.357268, -54.974196, 50.415578, -54.974196)</field>
-    <field name="solr_bbox">-88.357268 27.222251 -54.974196 50.415578</field>
-    <field name="solr_sw_pt">27.222251,-88.357268</field>
-    <field name="solr_ne_pt">50.415578,-54.974196</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/517/4/geoblacklight.xml
+++ b/517/4/geoblacklight.xml
@@ -39,12 +39,6 @@
     <field name="georss_box_s">36.098957 -84.268492 41.053629 -74.660606</field>
     <field name="georss_polygon_s">36.098957 -84.268492 36.098957 -74.660606 41.053629 -74.660606 41.053629 -84.268492 36.098957 -84.268492</field>
     <field name="solr_geom">ENVELOPE(-84.268492, -74.660606, 41.053629, -74.660606)</field>
-    <field name="solr_bbox">-84.268492 36.098957 -74.660606 41.053629</field>
-    <field name="solr_sw_pt">36.098957,-84.268492</field>
-    <field name="solr_ne_pt">41.053629,-74.660606</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/518/4/geoblacklight.xml
+++ b/518/4/geoblacklight.xml
@@ -38,12 +38,6 @@
     <field name="georss_box_s">35.923819 -79.045187 40.634346 -74.328558</field>
     <field name="georss_polygon_s">35.923819 -79.045187 35.923819 -74.328558 40.634346 -74.328558 40.634346 -79.045187 35.923819 -79.045187</field>
     <field name="solr_geom">ENVELOPE(-79.045187, -74.328558, 40.634346, -74.328558)</field>
-    <field name="solr_bbox">-79.045187 35.923819 -74.328558 40.634346</field>
-    <field name="solr_sw_pt">35.923819,-79.045187</field>
-    <field name="solr_ne_pt">40.634346,-74.328558</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/520/4/geoblacklight.xml
+++ b/520/4/geoblacklight.xml
@@ -33,12 +33,6 @@ Credit: Area Table 755 1752 Bowen</field>
     <field name="georss_box_s">-90 -78.24992 90 -73.86706</field>
     <field name="georss_polygon_s">-90 -78.24992 -90 -73.86706 90 -73.86706 90 -78.24992 -90 -78.24992</field>
     <field name="solr_geom">ENVELOPE(-78.24992, -73.86706, 90, -73.86706)</field>
-    <field name="solr_bbox">-78.24992 -90 -73.86706 90</field>
-    <field name="solr_sw_pt">-90,-78.24992</field>
-    <field name="solr_ne_pt">90,-73.86706</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/522/4/geoblacklight.xml
+++ b/522/4/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.045 -80.07965 40.133 -75.46588</field>
     <field name="georss_polygon_s">37.045 -80.07965 37.045 -75.46588 40.133 -75.46588 40.133 -80.07965 37.045 -80.07965</field>
     <field name="solr_geom">ENVELOPE(-80.07965, -75.46588, 40.133, -75.46588)</field>
-    <field name="solr_bbox">-80.07965 37.045 -75.46588 40.133</field>
-    <field name="solr_sw_pt">37.045,-80.07965</field>
-    <field name="solr_ne_pt">40.133,-75.46588</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/525/4/geoblacklight.xml
+++ b/525/4/geoblacklight.xml
@@ -33,12 +33,6 @@ Credit: Area Table 755-421 1781 Officer</field>
     <field name="georss_box_s">36.446 -77.07914 37.826 -75.46295</field>
     <field name="georss_polygon_s">36.446 -77.07914 36.446 -75.46295 37.826 -75.46295 37.826 -77.07914 36.446 -77.07914</field>
     <field name="solr_geom">ENVELOPE(-77.07914, -75.46295, 37.826, -75.46295)</field>
-    <field name="solr_bbox">-77.07914 36.446 -75.46295 37.826</field>
-    <field name="solr_sw_pt">36.446,-77.07914</field>
-    <field name="solr_ne_pt">37.826,-75.46295</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/526/4/geoblacklight.xml
+++ b/526/4/geoblacklight.xml
@@ -34,12 +34,6 @@
     <field name="georss_box_s">36.383381 -78.255913 40.613740 -72.798367</field>
     <field name="georss_polygon_s">36.383381 -78.255913 36.383381 -72.798367 40.613740 -72.798367 40.613740 -78.255913 36.383381 -78.255913</field>
     <field name="solr_geom">ENVELOPE(-78.255913, -72.798367, 40.613740, -72.798367)</field>
-    <field name="solr_bbox">-78.255913 36.383381 -72.798367 40.613740</field>
-    <field name="solr_sw_pt">36.383381,-78.255913</field>
-    <field name="solr_ne_pt">40.613740,-72.798367</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/10/geoblacklight.xml
+++ b/531/10/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/11/geoblacklight.xml
+++ b/531/11/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/12/geoblacklight.xml
+++ b/531/12/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/13/geoblacklight.xml
+++ b/531/13/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/14/geoblacklight.xml
+++ b/531/14/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/15/geoblacklight.xml
+++ b/531/15/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/16/geoblacklight.xml
+++ b/531/16/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/17/geoblacklight.xml
+++ b/531/17/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/18/geoblacklight.xml
+++ b/531/18/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/19/geoblacklight.xml
+++ b/531/19/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/20/geoblacklight.xml
+++ b/531/20/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/21/geoblacklight.xml
+++ b/531/21/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/22/geoblacklight.xml
+++ b/531/22/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/23/geoblacklight.xml
+++ b/531/23/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/24/geoblacklight.xml
+++ b/531/24/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/25/geoblacklight.xml
+++ b/531/25/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/26/geoblacklight.xml
+++ b/531/26/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/27/geoblacklight.xml
+++ b/531/27/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/28/geoblacklight.xml
+++ b/531/28/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/29/geoblacklight.xml
+++ b/531/29/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/30/geoblacklight.xml
+++ b/531/30/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/31/geoblacklight.xml
+++ b/531/31/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/32/geoblacklight.xml
+++ b/531/32/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/33/geoblacklight.xml
+++ b/531/33/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/34/geoblacklight.xml
+++ b/531/34/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/35/geoblacklight.xml
+++ b/531/35/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/36/geoblacklight.xml
+++ b/531/36/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/37/geoblacklight.xml
+++ b/531/37/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/38/geoblacklight.xml
+++ b/531/38/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/39/geoblacklight.xml
+++ b/531/39/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/4/geoblacklight.xml
+++ b/531/4/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/40/geoblacklight.xml
+++ b/531/40/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/41/geoblacklight.xml
+++ b/531/41/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/42/geoblacklight.xml
+++ b/531/42/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/43/geoblacklight.xml
+++ b/531/43/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/44/geoblacklight.xml
+++ b/531/44/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/45/geoblacklight.xml
+++ b/531/45/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/46/geoblacklight.xml
+++ b/531/46/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/47/geoblacklight.xml
+++ b/531/47/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/48/geoblacklight.xml
+++ b/531/48/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/49/geoblacklight.xml
+++ b/531/49/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/5/geoblacklight.xml
+++ b/531/5/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/50/geoblacklight.xml
+++ b/531/50/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/51/geoblacklight.xml
+++ b/531/51/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/6/geoblacklight.xml
+++ b/531/6/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/7/geoblacklight.xml
+++ b/531/7/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/8/geoblacklight.xml
+++ b/531/8/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/531/9/geoblacklight.xml
+++ b/531/9/geoblacklight.xml
@@ -89,12 +89,6 @@
     <field name="georss_box_s">25.837377 -179.147340 71.389612 -66.949426</field>
     <field name="georss_polygon_s">25.837377 -179.147340 25.837377 -66.949426 71.389612 -66.949426 71.389612 -179.147340 25.837377 -179.147340</field>
     <field name="solr_geom">ENVELOPE(-179.147340, -66.949426, 71.389612, -66.949426)</field>
-    <field name="solr_bbox">-179.147340 25.837377 -66.949426 71.389612</field>
-    <field name="solr_sw_pt">25.837377,-179.147340</field>
-    <field name="solr_ne_pt">71.389612,-66.949426</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/532/4/geoblacklight.xml
+++ b/532/4/geoblacklight.xml
@@ -33,12 +33,6 @@ Credit: Area Table 74 1616 Smith 1635</field>
     <field name="georss_box_s">39.75 -74.45 44 -68</field>
     <field name="georss_polygon_s">39.75 -74.45 39.75 -68 44 -68 44 -74.45 39.75 -74.45</field>
     <field name="solr_geom">ENVELOPE(-74.45, -68, 44, -68)</field>
-    <field name="solr_bbox">-74.45 39.75 -68 44</field>
-    <field name="solr_sw_pt">39.75,-74.45</field>
-    <field name="solr_ne_pt">44,-68</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/533/4/geoblacklight.xml
+++ b/533/4/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">36.220 -78.530 39.453 -74.309</field>
     <field name="georss_polygon_s">36.220 -78.530 36.220 -74.309 39.453 -74.309 39.453 -78.530 36.220 -78.530</field>
     <field name="solr_geom">ENVELOPE(-78.530, -74.309, 39.453, -74.309)</field>
-    <field name="solr_bbox">-78.530 36.220 -74.309 39.453</field>
-    <field name="solr_sw_pt">36.220,-78.530</field>
-    <field name="solr_ne_pt">39.453,-74.309</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/534/4/geoblacklight.xml
+++ b/534/4/geoblacklight.xml
@@ -35,12 +35,6 @@ Credit: Area Table 75 1861 Harpers</field>
     <field name="georss_box_s">23.25 -97.4 41.37 -75.1</field>
     <field name="georss_polygon_s">23.25 -97.4 23.25 -75.1 41.37 -75.1 41.37 -97.4 23.25 -97.4</field>
     <field name="solr_geom">ENVELOPE(-97.4, -75.1, 41.37, -75.1)</field>
-    <field name="solr_bbox">-97.4 23.25 -75.1 41.37</field>
-    <field name="solr_sw_pt">23.25,-97.4</field>
-    <field name="solr_ne_pt">41.37,-75.1</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/535/4/geoblacklight.xml
+++ b/535/4/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">36.988 -79.613 38.74 -75.999</field>
     <field name="georss_polygon_s">36.988 -79.613 36.988 -75.999 38.74 -75.999 38.74 -79.613 36.988 -79.613</field>
     <field name="solr_geom">ENVELOPE(-79.613, -75.999, 38.74, -75.999)</field>
-    <field name="solr_bbox">-79.613 36.988 -75.999 38.74</field>
-    <field name="solr_sw_pt">36.988,-79.613</field>
-    <field name="solr_ne_pt">38.74,-75.999</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/536/4/geoblacklight.xml
+++ b/536/4/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">36.54 -77.593 40.106 -74.559</field>
     <field name="georss_polygon_s">36.54 -77.593 36.54 -74.559 40.106 -74.559 40.106 -77.593 36.54 -77.593</field>
     <field name="solr_geom">ENVELOPE(-77.593, -74.559, 40.106, -74.559)</field>
-    <field name="solr_bbox">-77.593 36.54 -74.559 40.106</field>
-    <field name="solr_sw_pt">36.54,-77.593</field>
-    <field name="solr_ne_pt">40.106,-74.559</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/537/4/geoblacklight.xml
+++ b/537/4/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">36.2 -79.2 40.5 -73.4</field>
     <field name="georss_polygon_s">36.2 -79.2 36.2 -73.4 40.5 -73.4 40.5 -79.2 36.2 -79.2</field>
     <field name="solr_geom">ENVELOPE(-79.2, -73.4, 40.5, -73.4)</field>
-    <field name="solr_bbox">-79.2 36.2 -73.4 40.5</field>
-    <field name="solr_sw_pt">36.2,-79.2</field>
-    <field name="solr_ne_pt">40.5,-73.4</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/538/4/geoblacklight.xml
+++ b/538/4/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">35.731 -84.104 40.511 -74</field>
     <field name="georss_polygon_s">35.731 -84.104 35.731 -74 40.511 -74 40.511 -84.104 35.731 -84.104</field>
     <field name="solr_geom">ENVELOPE(-84.104, -74, 40.511, -74)</field>
-    <field name="solr_bbox">-84.104 35.731 -74 40.511</field>
-    <field name="solr_sw_pt">35.731,-84.104</field>
-    <field name="solr_ne_pt">40.511,-74</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/540/4/geoblacklight.xml
+++ b/540/4/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">37.1 -76.6 37.27 -76.4</field>
     <field name="georss_polygon_s">37.1 -76.6 37.1 -76.4 37.27 -76.4 37.27 -76.6 37.1 -76.6</field>
     <field name="solr_geom">ENVELOPE(-76.6, -76.4, 37.27, -76.4)</field>
-    <field name="solr_bbox">-76.6 37.1 -76.4 37.27</field>
-    <field name="solr_sw_pt">37.1,-76.6</field>
-    <field name="solr_ne_pt">37.27,-76.4</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/541/4/geoblacklight.xml
+++ b/541/4/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">31.992 -83.413 35.279 -78.483</field>
     <field name="georss_polygon_s">31.992 -83.413 31.992 -78.483 35.279 -78.483 35.279 -83.413 31.992 -83.413</field>
     <field name="solr_geom">ENVELOPE(-83.413, -78.483, 35.279, -78.483)</field>
-    <field name="solr_bbox">-83.413 31.992 -78.483 35.279</field>
-    <field name="solr_sw_pt">31.992,-83.413</field>
-    <field name="solr_ne_pt">35.279,-78.483</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/541/5/geoblacklight.xml
+++ b/541/5/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">31.992 -83.413 35.279 -78.483</field>
     <field name="georss_polygon_s">31.992 -83.413 31.992 -78.483 35.279 -78.483 35.279 -83.413 31.992 -83.413</field>
     <field name="solr_geom">ENVELOPE(-83.413, -78.483, 35.279, -78.483)</field>
-    <field name="solr_bbox">-83.413 31.992 -78.483 35.279</field>
-    <field name="solr_sw_pt">31.992,-83.413</field>
-    <field name="solr_ne_pt">35.279,-78.483</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/10/geoblacklight.xml
+++ b/543/10/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/11/geoblacklight.xml
+++ b/543/11/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/12/geoblacklight.xml
+++ b/543/12/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/13/geoblacklight.xml
+++ b/543/13/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/14/geoblacklight.xml
+++ b/543/14/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/15/geoblacklight.xml
+++ b/543/15/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/16/geoblacklight.xml
+++ b/543/16/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/17/geoblacklight.xml
+++ b/543/17/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/4/geoblacklight.xml
+++ b/543/4/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/5/geoblacklight.xml
+++ b/543/5/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/6/geoblacklight.xml
+++ b/543/6/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/7/geoblacklight.xml
+++ b/543/7/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/8/geoblacklight.xml
+++ b/543/8/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/543/9/geoblacklight.xml
+++ b/543/9/geoblacklight.xml
@@ -35,12 +35,6 @@
     <field name="georss_box_s">38.02109 -78.48596 38.06727 -78.55260</field>
     <field name="georss_polygon_s">38.02109 -78.48596 38.02109 -78.55260 38.06727 -78.55260 38.06727 -78.48596 38.02109 -78.48596</field>
     <field name="solr_geom">ENVELOPE(-78.48596, -78.55260, 38.06727, -78.55260)</field>
-    <field name="solr_bbox">-78.48596 38.02109 -78.55260 38.06727</field>
-    <field name="solr_sw_pt">38.02109,-78.48596</field>
-    <field name="solr_ne_pt">38.06727,-78.55260</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/544/4/geoblacklight.xml
+++ b/544/4/geoblacklight.xml
@@ -38,12 +38,6 @@
     <field name="georss_box_s">37.722 -78.84 38.278 -78.207</field>
     <field name="georss_polygon_s">37.722 -78.84 37.722 -78.207 38.278 -78.207 38.278 -78.84 37.722 -78.84</field>
     <field name="solr_geom">ENVELOPE(-78.84, -78.207, 38.278, -78.207)</field>
-    <field name="solr_bbox">-78.84 37.722 -78.207 38.278</field>
-    <field name="solr_sw_pt">37.722,-78.84</field>
-    <field name="solr_ne_pt">38.278,-78.207</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/10/geoblacklight.xml
+++ b/545/10/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/11/geoblacklight.xml
+++ b/545/11/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/12/geoblacklight.xml
+++ b/545/12/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/13/geoblacklight.xml
+++ b/545/13/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/14/geoblacklight.xml
+++ b/545/14/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/15/geoblacklight.xml
+++ b/545/15/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/16/geoblacklight.xml
+++ b/545/16/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/17/geoblacklight.xml
+++ b/545/17/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/18/geoblacklight.xml
+++ b/545/18/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/19/geoblacklight.xml
+++ b/545/19/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/20/geoblacklight.xml
+++ b/545/20/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/21/geoblacklight.xml
+++ b/545/21/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/22/geoblacklight.xml
+++ b/545/22/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/23/geoblacklight.xml
+++ b/545/23/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/24/geoblacklight.xml
+++ b/545/24/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/25/geoblacklight.xml
+++ b/545/25/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/26/geoblacklight.xml
+++ b/545/26/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/27/geoblacklight.xml
+++ b/545/27/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/28/geoblacklight.xml
+++ b/545/28/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/29/geoblacklight.xml
+++ b/545/29/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/30/geoblacklight.xml
+++ b/545/30/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/31/geoblacklight.xml
+++ b/545/31/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/32/geoblacklight.xml
+++ b/545/32/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/33/geoblacklight.xml
+++ b/545/33/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/34/geoblacklight.xml
+++ b/545/34/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/35/geoblacklight.xml
+++ b/545/35/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/36/geoblacklight.xml
+++ b/545/36/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/37/geoblacklight.xml
+++ b/545/37/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/38/geoblacklight.xml
+++ b/545/38/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/39/geoblacklight.xml
+++ b/545/39/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/4/geoblacklight.xml
+++ b/545/4/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/40/geoblacklight.xml
+++ b/545/40/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/41/geoblacklight.xml
+++ b/545/41/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/42/geoblacklight.xml
+++ b/545/42/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/43/geoblacklight.xml
+++ b/545/43/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/44/geoblacklight.xml
+++ b/545/44/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/45/geoblacklight.xml
+++ b/545/45/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/46/geoblacklight.xml
+++ b/545/46/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/47/geoblacklight.xml
+++ b/545/47/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/48/geoblacklight.xml
+++ b/545/48/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/49/geoblacklight.xml
+++ b/545/49/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/5/geoblacklight.xml
+++ b/545/5/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/50/geoblacklight.xml
+++ b/545/50/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/51/geoblacklight.xml
+++ b/545/51/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/52/geoblacklight.xml
+++ b/545/52/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/53/geoblacklight.xml
+++ b/545/53/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/6/geoblacklight.xml
+++ b/545/6/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/7/geoblacklight.xml
+++ b/545/7/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/8/geoblacklight.xml
+++ b/545/8/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/545/9/geoblacklight.xml
+++ b/545/9/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/10/geoblacklight.xml
+++ b/546/10/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/11/geoblacklight.xml
+++ b/546/11/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/12/geoblacklight.xml
+++ b/546/12/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/13/geoblacklight.xml
+++ b/546/13/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/14/geoblacklight.xml
+++ b/546/14/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/15/geoblacklight.xml
+++ b/546/15/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/16/geoblacklight.xml
+++ b/546/16/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/17/geoblacklight.xml
+++ b/546/17/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/18/geoblacklight.xml
+++ b/546/18/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/19/geoblacklight.xml
+++ b/546/19/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/20/geoblacklight.xml
+++ b/546/20/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/21/geoblacklight.xml
+++ b/546/21/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/22/geoblacklight.xml
+++ b/546/22/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/23/geoblacklight.xml
+++ b/546/23/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/24/geoblacklight.xml
+++ b/546/24/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/25/geoblacklight.xml
+++ b/546/25/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/26/geoblacklight.xml
+++ b/546/26/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/27/geoblacklight.xml
+++ b/546/27/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/28/geoblacklight.xml
+++ b/546/28/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/29/geoblacklight.xml
+++ b/546/29/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/30/geoblacklight.xml
+++ b/546/30/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/31/geoblacklight.xml
+++ b/546/31/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/32/geoblacklight.xml
+++ b/546/32/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/33/geoblacklight.xml
+++ b/546/33/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/34/geoblacklight.xml
+++ b/546/34/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/35/geoblacklight.xml
+++ b/546/35/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/36/geoblacklight.xml
+++ b/546/36/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/4/geoblacklight.xml
+++ b/546/4/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/5/geoblacklight.xml
+++ b/546/5/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/6/geoblacklight.xml
+++ b/546/6/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/7/geoblacklight.xml
+++ b/546/7/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/8/geoblacklight.xml
+++ b/546/8/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/546/9/geoblacklight.xml
+++ b/546/9/geoblacklight.xml
@@ -78,12 +78,6 @@ see our help page in the OnLine Resources below.</field>
     <field name="georss_box_s">37.988007 -78.524842 38.050745 -78.451464</field>
     <field name="georss_polygon_s">37.988007 -78.524842 37.988007 -78.451464 38.050745 -78.451464 38.050745 -78.524842 37.988007 -78.524842</field>
     <field name="solr_geom">ENVELOPE(-78.524842, -78.451464, 38.050745, -78.451464)</field>
-    <field name="solr_bbox">-78.524842 37.988007 -78.451464 38.050745</field>
-    <field name="solr_sw_pt">37.988007,-78.524842</field>
-    <field name="solr_ne_pt">38.050745,-78.451464</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/547/4/geoblacklight.xml
+++ b/547/4/geoblacklight.xml
@@ -33,12 +33,6 @@
     <field name="georss_box_s">22.785 -125.515 50.499 -51.699</field>
     <field name="georss_polygon_s">22.785 -125.515 22.785 -51.699 50.499 -51.699 50.499 -125.515 22.785 -125.515</field>
     <field name="solr_geom">ENVELOPE(-125.515, -51.699, 50.499, -51.699)</field>
-    <field name="solr_bbox">-125.515 22.785 -51.699 50.499</field>
-    <field name="solr_sw_pt">22.785,-125.515</field>
-    <field name="solr_ne_pt">50.499,-51.699</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/548/4/geoblacklight.xml
+++ b/548/4/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">-10 -169.1 88.9 -25</field>
     <field name="georss_polygon_s">-10 -169.1 -10 -25 88.9 -25 88.9 -169.1 -10 -169.1</field>
     <field name="solr_geom">ENVELOPE(-169.1, -25, 88.9, -25)</field>
-    <field name="solr_bbox">-169.1 -10 -25 88.9</field>
-    <field name="solr_sw_pt">-10,-169.1</field>
-    <field name="solr_ne_pt">88.9,-25</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/549/4/geoblacklight.xml
+++ b/549/4/geoblacklight.xml
@@ -32,12 +32,6 @@
     <field name="georss_box_s">32.2 -88 66 -64</field>
     <field name="georss_polygon_s">32.2 -88 32.2 -64 66 -64 66 -88 32.2 -88</field>
     <field name="solr_geom">ENVELOPE(-88, -64, 66, -64)</field>
-    <field name="solr_bbox">-88 32.2 -64 66</field>
-    <field name="solr_sw_pt">32.2,-88</field>
-    <field name="solr_ne_pt">66,-64</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/557/4/geoblacklight.xml
+++ b/557/4/geoblacklight.xml
@@ -41,12 +41,6 @@
     <field name="georss_box_s">37.722 -78.84 38.278 -78.207</field>
     <field name="georss_polygon_s">37.722 -78.84 37.722 -78.207 38.278 -78.207 38.278 -78.84 37.722 -78.84</field>
     <field name="solr_geom">ENVELOPE(-78.84, -78.207, 38.278, -78.207)</field>
-    <field name="solr_bbox">-78.84 37.722 -78.207 38.278</field>
-    <field name="solr_sw_pt">37.722,-78.84</field>
-    <field name="solr_ne_pt">38.278,-78.207</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/557/5/geoblacklight.xml
+++ b/557/5/geoblacklight.xml
@@ -41,12 +41,6 @@
     <field name="georss_box_s">37.722 -78.84 38.278 -78.207</field>
     <field name="georss_polygon_s">37.722 -78.84 37.722 -78.207 38.278 -78.207 38.278 -78.84 37.722 -78.84</field>
     <field name="solr_geom">ENVELOPE(-78.84, -78.207, 38.278, -78.207)</field>
-    <field name="solr_bbox">-78.84 37.722 -78.207 38.278</field>
-    <field name="solr_sw_pt">37.722,-78.84</field>
-    <field name="solr_ne_pt">38.278,-78.207</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/558/4/geoblacklight.xml
+++ b/558/4/geoblacklight.xml
@@ -31,12 +31,6 @@
     <field name="georss_box_s">0.0933 -130.046 67.288 -52.231</field>
     <field name="georss_polygon_s">0.0933 -130.046 0.0933 -52.231 67.288 -52.231 67.288 -130.046 0.0933 -130.046</field>
     <field name="solr_geom">ENVELOPE(-130.046, -52.231, 67.288, -52.231)</field>
-    <field name="solr_bbox">-130.046 0.0933 -52.231 67.288</field>
-    <field name="solr_sw_pt">0.0933,-130.046</field>
-    <field name="solr_ne_pt">67.288,-52.231</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/560/4/geoblacklight.xml
+++ b/560/4/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">37.045 -80.07965 40.133 -75.46588</field>
     <field name="georss_polygon_s">37.045 -80.07965 37.045 -75.46588 40.133 -75.46588 40.133 -80.07965 37.045 -80.07965</field>
     <field name="solr_geom">ENVELOPE(-80.07965, -75.46588, 40.133, -75.46588)</field>
-    <field name="solr_bbox">-80.07965 37.045 -75.46588 40.133</field>
-    <field name="solr_sw_pt">37.045,-80.07965</field>
-    <field name="solr_ne_pt">40.133,-75.46588</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/561/4/geoblacklight.xml
+++ b/561/4/geoblacklight.xml
@@ -39,12 +39,6 @@
     <field name="georss_box_s">37.045 -80.07965 40.133 -75.46588</field>
     <field name="georss_polygon_s">37.045 -80.07965 37.045 -75.46588 40.133 -75.46588 40.133 -80.07965 37.045 -80.07965</field>
     <field name="solr_geom">ENVELOPE(-80.07965, -75.46588, 40.133, -75.46588)</field>
-    <field name="solr_bbox">-80.07965 37.045 -75.46588 40.133</field>
-    <field name="solr_sw_pt">37.045,-80.07965</field>
-    <field name="solr_ne_pt">40.133,-75.46588</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/562/4/geoblacklight.xml
+++ b/562/4/geoblacklight.xml
@@ -37,12 +37,6 @@
     <field name="georss_box_s">6.1320 -123.4152 57.2650 14.5747</field>
     <field name="georss_polygon_s">6.1320 -123.4152 6.1320 14.5747 57.2650 14.5747 57.2650 -123.4152 6.1320 -123.4152</field>
     <field name="solr_geom">ENVELOPE(-123.4152, 14.5747, 57.2650, 14.5747)</field>
-    <field name="solr_bbox">-123.4152 6.1320 14.5747 57.2650</field>
-    <field name="solr_sw_pt">6.1320,-123.4152</field>
-    <field name="solr_ne_pt">57.2650,14.5747</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/10/geoblacklight.xml
+++ b/563/10/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/11/geoblacklight.xml
+++ b/563/11/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/12/geoblacklight.xml
+++ b/563/12/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/13/geoblacklight.xml
+++ b/563/13/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/14/geoblacklight.xml
+++ b/563/14/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/15/geoblacklight.xml
+++ b/563/15/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/16/geoblacklight.xml
+++ b/563/16/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/17/geoblacklight.xml
+++ b/563/17/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/18/geoblacklight.xml
+++ b/563/18/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/19/geoblacklight.xml
+++ b/563/19/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/20/geoblacklight.xml
+++ b/563/20/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/21/geoblacklight.xml
+++ b/563/21/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/22/geoblacklight.xml
+++ b/563/22/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/23/geoblacklight.xml
+++ b/563/23/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/24/geoblacklight.xml
+++ b/563/24/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/25/geoblacklight.xml
+++ b/563/25/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/26/geoblacklight.xml
+++ b/563/26/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/27/geoblacklight.xml
+++ b/563/27/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/28/geoblacklight.xml
+++ b/563/28/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/29/geoblacklight.xml
+++ b/563/29/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/30/geoblacklight.xml
+++ b/563/30/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/31/geoblacklight.xml
+++ b/563/31/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/32/geoblacklight.xml
+++ b/563/32/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/33/geoblacklight.xml
+++ b/563/33/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/34/geoblacklight.xml
+++ b/563/34/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/35/geoblacklight.xml
+++ b/563/35/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/36/geoblacklight.xml
+++ b/563/36/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/37/geoblacklight.xml
+++ b/563/37/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/38/geoblacklight.xml
+++ b/563/38/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/39/geoblacklight.xml
+++ b/563/39/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/4/geoblacklight.xml
+++ b/563/4/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/40/geoblacklight.xml
+++ b/563/40/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/41/geoblacklight.xml
+++ b/563/41/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/42/geoblacklight.xml
+++ b/563/42/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/43/geoblacklight.xml
+++ b/563/43/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/44/geoblacklight.xml
+++ b/563/44/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/45/geoblacklight.xml
+++ b/563/45/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/46/geoblacklight.xml
+++ b/563/46/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/47/geoblacklight.xml
+++ b/563/47/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/48/geoblacklight.xml
+++ b/563/48/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/49/geoblacklight.xml
+++ b/563/49/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/5/geoblacklight.xml
+++ b/563/5/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/50/geoblacklight.xml
+++ b/563/50/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/51/geoblacklight.xml
+++ b/563/51/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/52/geoblacklight.xml
+++ b/563/52/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/53/geoblacklight.xml
+++ b/563/53/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/54/geoblacklight.xml
+++ b/563/54/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/55/geoblacklight.xml
+++ b/563/55/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/56/geoblacklight.xml
+++ b/563/56/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/57/geoblacklight.xml
+++ b/563/57/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/58/geoblacklight.xml
+++ b/563/58/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/59/geoblacklight.xml
+++ b/563/59/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/6/geoblacklight.xml
+++ b/563/6/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/60/geoblacklight.xml
+++ b/563/60/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/61/geoblacklight.xml
+++ b/563/61/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/62/geoblacklight.xml
+++ b/563/62/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/63/geoblacklight.xml
+++ b/563/63/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/64/geoblacklight.xml
+++ b/563/64/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/65/geoblacklight.xml
+++ b/563/65/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/66/geoblacklight.xml
+++ b/563/66/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/67/geoblacklight.xml
+++ b/563/67/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/68/geoblacklight.xml
+++ b/563/68/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/69/geoblacklight.xml
+++ b/563/69/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/7/geoblacklight.xml
+++ b/563/7/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/70/geoblacklight.xml
+++ b/563/70/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/71/geoblacklight.xml
+++ b/563/71/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/72/geoblacklight.xml
+++ b/563/72/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/73/geoblacklight.xml
+++ b/563/73/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/74/geoblacklight.xml
+++ b/563/74/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/75/geoblacklight.xml
+++ b/563/75/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/76/geoblacklight.xml
+++ b/563/76/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/77/geoblacklight.xml
+++ b/563/77/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/78/geoblacklight.xml
+++ b/563/78/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/79/geoblacklight.xml
+++ b/563/79/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/8/geoblacklight.xml
+++ b/563/8/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/80/geoblacklight.xml
+++ b/563/80/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/81/geoblacklight.xml
+++ b/563/81/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/82/geoblacklight.xml
+++ b/563/82/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/83/geoblacklight.xml
+++ b/563/83/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/84/geoblacklight.xml
+++ b/563/84/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/85/geoblacklight.xml
+++ b/563/85/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/86/geoblacklight.xml
+++ b/563/86/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/87/geoblacklight.xml
+++ b/563/87/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/88/geoblacklight.xml
+++ b/563/88/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/89/geoblacklight.xml
+++ b/563/89/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/9/geoblacklight.xml
+++ b/563/9/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/90/geoblacklight.xml
+++ b/563/90/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/91/geoblacklight.xml
+++ b/563/91/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/563/92/geoblacklight.xml
+++ b/563/92/geoblacklight.xml
@@ -89,12 +89,6 @@ These datasets reside on the NEW SLAB SHARED DRIVE, and have been uploaded into 
     <field name="georss_box_s">37.72255 -78.83913 38.27794 -78.20801</field>
     <field name="georss_polygon_s">37.72255 -78.83913 37.72255 -78.20801 38.27794 -78.20801 38.27794 -78.83913 37.72255 -78.83913</field>
     <field name="solr_geom">ENVELOPE(-78.83913, -78.20801, 38.27794, -78.20801)</field>
-    <field name="solr_bbox">-78.83913 37.72255 -78.20801 38.27794</field>
-    <field name="solr_sw_pt">37.72255,-78.83913</field>
-    <field name="solr_ne_pt">38.27794,-78.20801</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/10/geoblacklight.xml
+++ b/564/10/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/11/geoblacklight.xml
+++ b/564/11/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/12/geoblacklight.xml
+++ b/564/12/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/13/geoblacklight.xml
+++ b/564/13/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/14/geoblacklight.xml
+++ b/564/14/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/15/geoblacklight.xml
+++ b/564/15/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/16/geoblacklight.xml
+++ b/564/16/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/17/geoblacklight.xml
+++ b/564/17/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/18/geoblacklight.xml
+++ b/564/18/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/19/geoblacklight.xml
+++ b/564/19/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/20/geoblacklight.xml
+++ b/564/20/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/21/geoblacklight.xml
+++ b/564/21/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/22/geoblacklight.xml
+++ b/564/22/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/23/geoblacklight.xml
+++ b/564/23/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/24/geoblacklight.xml
+++ b/564/24/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/25/geoblacklight.xml
+++ b/564/25/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/26/geoblacklight.xml
+++ b/564/26/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/27/geoblacklight.xml
+++ b/564/27/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/28/geoblacklight.xml
+++ b/564/28/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/29/geoblacklight.xml
+++ b/564/29/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/30/geoblacklight.xml
+++ b/564/30/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/31/geoblacklight.xml
+++ b/564/31/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/4/geoblacklight.xml
+++ b/564/4/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/5/geoblacklight.xml
+++ b/564/5/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/6/geoblacklight.xml
+++ b/564/6/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/7/geoblacklight.xml
+++ b/564/7/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/8/geoblacklight.xml
+++ b/564/8/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/564/9/geoblacklight.xml
+++ b/564/9/geoblacklight.xml
@@ -73,12 +73,6 @@ Datasets/Layers included in this datastack (with non-exclusive list of included 
     <field name="georss_box_s">37.97745 -78.67702 38.19625 -78.34292</field>
     <field name="georss_polygon_s">37.97745 -78.67702 37.97745 -78.34292 38.19625 -78.34292 38.19625 -78.67702 37.97745 -78.67702</field>
     <field name="solr_geom">ENVELOPE(-78.67702, -78.34292, 38.19625, -78.34292)</field>
-    <field name="solr_bbox">-78.67702 37.97745 -78.34292 38.19625</field>
-    <field name="solr_sw_pt">37.97745,-78.67702</field>
-    <field name="solr_ne_pt">38.19625,-78.34292</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/565/10/geoblacklight.xml
+++ b/565/10/geoblacklight.xml
@@ -60,12 +60,6 @@ faculty and staff of the University of Virginia.
     <field name="georss_box_s">36.5 -83.75 39.5 -75.125</field>
     <field name="georss_polygon_s">36.5 -83.75 36.5 -75.125 39.5 -75.125 39.5 -83.75 36.5 -83.75</field>
     <field name="solr_geom">ENVELOPE(-83.75, -75.125, 39.5, -75.125)</field>
-    <field name="solr_bbox">-83.75 36.5 -75.125 39.5</field>
-    <field name="solr_sw_pt">36.5,-83.75</field>
-    <field name="solr_ne_pt">39.5,-75.125</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/565/4/geoblacklight.xml
+++ b/565/4/geoblacklight.xml
@@ -60,12 +60,6 @@ faculty and staff of the University of Virginia.
     <field name="georss_box_s">36.5 -83.75 39.5 -75.125</field>
     <field name="georss_polygon_s">36.5 -83.75 36.5 -75.125 39.5 -75.125 39.5 -83.75 36.5 -83.75</field>
     <field name="solr_geom">ENVELOPE(-83.75, -75.125, 39.5, -75.125)</field>
-    <field name="solr_bbox">-83.75 36.5 -75.125 39.5</field>
-    <field name="solr_sw_pt">36.5,-83.75</field>
-    <field name="solr_ne_pt">39.5,-75.125</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/565/5/geoblacklight.xml
+++ b/565/5/geoblacklight.xml
@@ -60,12 +60,6 @@ faculty and staff of the University of Virginia.
     <field name="georss_box_s">36.5 -83.75 39.5 -75.125</field>
     <field name="georss_polygon_s">36.5 -83.75 36.5 -75.125 39.5 -75.125 39.5 -83.75 36.5 -83.75</field>
     <field name="solr_geom">ENVELOPE(-83.75, -75.125, 39.5, -75.125)</field>
-    <field name="solr_bbox">-83.75 36.5 -75.125 39.5</field>
-    <field name="solr_sw_pt">36.5,-83.75</field>
-    <field name="solr_ne_pt">39.5,-75.125</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/565/6/geoblacklight.xml
+++ b/565/6/geoblacklight.xml
@@ -60,12 +60,6 @@ faculty and staff of the University of Virginia.
     <field name="georss_box_s">36.5 -83.75 39.5 -75.125</field>
     <field name="georss_polygon_s">36.5 -83.75 36.5 -75.125 39.5 -75.125 39.5 -83.75 36.5 -83.75</field>
     <field name="solr_geom">ENVELOPE(-83.75, -75.125, 39.5, -75.125)</field>
-    <field name="solr_bbox">-83.75 36.5 -75.125 39.5</field>
-    <field name="solr_sw_pt">36.5,-83.75</field>
-    <field name="solr_ne_pt">39.5,-75.125</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/565/7/geoblacklight.xml
+++ b/565/7/geoblacklight.xml
@@ -60,12 +60,6 @@ faculty and staff of the University of Virginia.
     <field name="georss_box_s">36.5 -83.75 39.5 -75.125</field>
     <field name="georss_polygon_s">36.5 -83.75 36.5 -75.125 39.5 -75.125 39.5 -83.75 36.5 -83.75</field>
     <field name="solr_geom">ENVELOPE(-83.75, -75.125, 39.5, -75.125)</field>
-    <field name="solr_bbox">-83.75 36.5 -75.125 39.5</field>
-    <field name="solr_sw_pt">36.5,-83.75</field>
-    <field name="solr_ne_pt">39.5,-75.125</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/565/8/geoblacklight.xml
+++ b/565/8/geoblacklight.xml
@@ -60,12 +60,6 @@ faculty and staff of the University of Virginia.
     <field name="georss_box_s">36.5 -83.75 39.5 -75.125</field>
     <field name="georss_polygon_s">36.5 -83.75 36.5 -75.125 39.5 -75.125 39.5 -83.75 36.5 -83.75</field>
     <field name="solr_geom">ENVELOPE(-83.75, -75.125, 39.5, -75.125)</field>
-    <field name="solr_bbox">-83.75 36.5 -75.125 39.5</field>
-    <field name="solr_sw_pt">36.5,-83.75</field>
-    <field name="solr_ne_pt">39.5,-75.125</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/565/9/geoblacklight.xml
+++ b/565/9/geoblacklight.xml
@@ -60,12 +60,6 @@ faculty and staff of the University of Virginia.
     <field name="georss_box_s">36.5 -83.75 39.5 -75.125</field>
     <field name="georss_polygon_s">36.5 -83.75 36.5 -75.125 39.5 -75.125 39.5 -83.75 36.5 -83.75</field>
     <field name="solr_geom">ENVELOPE(-83.75, -75.125, 39.5, -75.125)</field>
-    <field name="solr_bbox">-83.75 36.5 -75.125 39.5</field>
-    <field name="solr_sw_pt">36.5,-83.75</field>
-    <field name="solr_ne_pt">39.5,-75.125</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/567/4/geoblacklight.xml
+++ b/567/4/geoblacklight.xml
@@ -38,12 +38,6 @@ Also included is an additional zipped archive containing ArcGIS .LYR layer files
     <field name="georss_box_s">36.535133 -83.675682 39.465752 -75.097580</field>
     <field name="georss_polygon_s">36.535133 -83.675682 36.535133 -75.097580 39.465752 -75.097580 39.465752 -83.675682 36.535133 -83.675682</field>
     <field name="solr_geom">ENVELOPE(-83.675682, -75.097580, 39.465752, -75.097580)</field>
-    <field name="solr_bbox">-83.675682 36.535133 -75.097580 39.465752</field>
-    <field name="solr_sw_pt">36.535133,-83.675682</field>
-    <field name="solr_ne_pt">39.465752,-75.097580</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/567/5/geoblacklight.xml
+++ b/567/5/geoblacklight.xml
@@ -38,12 +38,6 @@ Also included is an additional zipped archive containing ArcGIS .LYR layer files
     <field name="georss_box_s">36.535133 -83.675682 39.465752 -75.097580</field>
     <field name="georss_polygon_s">36.535133 -83.675682 36.535133 -75.097580 39.465752 -75.097580 39.465752 -83.675682 36.535133 -83.675682</field>
     <field name="solr_geom">ENVELOPE(-83.675682, -75.097580, 39.465752, -75.097580)</field>
-    <field name="solr_bbox">-83.675682 36.535133 -75.097580 39.465752</field>
-    <field name="solr_sw_pt">36.535133,-83.675682</field>
-    <field name="solr_ne_pt">39.465752,-75.097580</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/567/6/geoblacklight.xml
+++ b/567/6/geoblacklight.xml
@@ -38,12 +38,6 @@ Also included is an additional zipped archive containing ArcGIS .LYR layer files
     <field name="georss_box_s">36.535133 -83.675682 39.465752 -75.097580</field>
     <field name="georss_polygon_s">36.535133 -83.675682 36.535133 -75.097580 39.465752 -75.097580 39.465752 -83.675682 36.535133 -83.675682</field>
     <field name="solr_geom">ENVELOPE(-83.675682, -75.097580, 39.465752, -75.097580)</field>
-    <field name="solr_bbox">-83.675682 36.535133 -75.097580 39.465752</field>
-    <field name="solr_sw_pt">36.535133,-83.675682</field>
-    <field name="solr_ne_pt">39.465752,-75.097580</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>

--- a/567/7/geoblacklight.xml
+++ b/567/7/geoblacklight.xml
@@ -38,12 +38,6 @@ Also included is an additional zipped archive containing ArcGIS .LYR layer files
     <field name="georss_box_s">36.535133 -83.675682 39.465752 -75.097580</field>
     <field name="georss_polygon_s">36.535133 -83.675682 36.535133 -75.097580 39.465752 -75.097580 39.465752 -83.675682 36.535133 -83.675682</field>
     <field name="solr_geom">ENVELOPE(-83.675682, -75.097580, 39.465752, -75.097580)</field>
-    <field name="solr_bbox">-83.675682 36.535133 -75.097580 39.465752</field>
-    <field name="solr_sw_pt">36.535133,-83.675682</field>
-    <field name="solr_ne_pt">39.465752,-75.097580</field>
     <field name="solr_year_i">2014</field>
-    <field name="solr_wms_url">http://gis.lib.virginia.edu/geoserver/wms</field>
-    <field name="solr_wfs_url">http://gis.lib.virginia.edu/geoserver/wfs</field>
-    <field name="solr_wcs_url">http://gis.lib.virginia.edu/geoserver/wcs</field>
   </doc>
 </add>


### PR DESCRIPTION
Hi Wayne,

We've deprecated several of the `solr_` fields in GeoBlacklight.
- `solr_bbox`: We use `solr_geom` instead. See https://github.com/geoblacklight/geoblacklight/issues/297
- `solr_ne_pt` and `solr_sw_pt`: These are deprecated for `solr_geom`
- `solr_wms_url`, `solr_wfs_url`, and `solr_wcs_url`: These are deprecated for `dct_references_s`.

Thanks,
-Darren
